### PR TITLE
The tests that compare the contents of Sets randomly fail

### DIFF
--- a/src/test/java/com/pholser/junit/quickcheck/Objects.java
+++ b/src/test/java/com/pholser/junit/quickcheck/Objects.java
@@ -27,6 +27,7 @@ package com.pholser.junit.quickcheck;
 
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Set;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
@@ -66,6 +67,9 @@ public class Objects {
 
         if (first == null || second == null)
             return false;
+        
+        if (first instanceof Set<?> && second instanceof Set<?>)
+            return linearDeepEquals((Set<?>) first, (Set<?>) second);
 
         if (first instanceof Collection<?> && second instanceof Collection<?>)
             return linearDeepEquals((Collection<?>) first, (Collection<?>) second);
@@ -105,4 +109,24 @@ public class Objects {
 
         return true;
     }
+    
+    private static boolean linearDeepEquals(Set<?> first, Set<?> second) {
+        if (first.size() != second.size())
+            return false;
+
+        for (Object o1 : first) {
+        	boolean found = false;
+        	for (Object o2 : second)
+        		if (deepEquals(o1, o2)) {
+        			found = true;
+        			break;
+        		}
+			if (!found) {
+				return false;
+			}
+        }
+
+        return true;
+    }
+
 }


### PR DESCRIPTION
Iteration over a set is not predictable in order; thus tests are randomly failing:

java.lang.AssertionError: 2'th value
Expected: an object that is deep-equals to <[8, 7]>
     got: <[7, 8]>

```
at org.junit.Assert.assertThat(Assert.java:780)
at com.pholser.junit.quickcheck.internal.generator.GeneratingUniformRandomValuesForTheoryParameterTest.insertsTheRandomValuesIntoAssignments(GeneratingUniformRandomValuesForTheoryParameterTest.java:102)
```
