### PR TITLE
Add import statements to first code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ JUnit's answer to function properties is the notion of _theories_. Programmers w
 theories, run using a special test runner:
 
 ```java
+    import org.junit.contrib.theories.*;
+    import static org.hamcrest.Matchers.*;
+    import static org.junit.Assert.*;
+    import static org.junit.Assume.*;
+    
     @RunWith(Theories.class)
     public class Accounts {
         @Theory public void withdrawingReducesBalance(


### PR DESCRIPTION
I thought it would be useful to have the explicit import statements, at least for the first example.

When I was working through learning to use the library, my IDE (eclipse) wasn't able to find the methods automatically. I ended up having to track down the APIs online to get the right package names imported. Also, although it's stated earlier about the contrib version, my IDE defaulted to the wrong ones without my prompting. Basically, just trying to make it easier for people exploring the library for the first time.

Awesome stuff, btw.
