### PR TITLE
For #65, filter available generators by config support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,16 +363,18 @@ satisfy a given theory parameter based on its type:
     }
 ```
 
-Any available generators that can produce something that is
-`java.io.Serializable` might be called on to generate a value for parameter
-`s` above. Because of this, any configuration annotations on a parameter or
-type use are ignored by a generator that cannot support the annotation. This
-may or may not matter depending on the nature of the theory you're writing.
+Only the available generators that can produce something that is
+`java.io.Serializable` *and* that support all the configuration annotations
+on a theory parameter will be called on to generate a value for that
+theory parameter. So, for example, for parameter `s` above, generators for
+integral values might be called upon, whereas generators for `ArrayList`s
+would not. junit-quickcheck will complain loudly if there are no such
+generators available.
 
-Also, if you have a family of generators that can produce members of a
-hierarchy, you may want to ensure that all the generators respect the same
-attributes of a given configuration annotation. Not doing so could lead to
-surprising results.
+If you have a family of generators that can produce members of a hierarchy,
+you may want to ensure that all the generators respect the same attributes
+of a given configuration annotation. Not doing so could lead to surprising
+results.
 
 ###### Aggregating configuration
 

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/GeneratorConfigurationException.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/GeneratorConfigurationException.java
@@ -1,0 +1,11 @@
+package com.pholser.junit.quickcheck.generator;
+
+public class GeneratorConfigurationException extends RuntimeException {
+    public GeneratorConfigurationException(String message) {
+        super(message);
+    }
+
+    public GeneratorConfigurationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/core/src/test/java/com/pholser/junit/quickcheck/ComponentizedGeneratorsDoNotPassConfigurationOnToComponentsTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ComponentizedGeneratorsDoNotPassConfigurationOnToComponentsTest.java
@@ -27,6 +27,7 @@ package com.pholser.junit.quickcheck;
 
 import com.pholser.junit.quickcheck.test.generator.Box;
 import com.pholser.junit.quickcheck.test.generator.Foo;
+import com.pholser.junit.quickcheck.test.generator.X;
 import org.junit.Test;
 import org.junit.contrib.theories.Theories;
 import org.junit.contrib.theories.Theory;
@@ -48,10 +49,10 @@ public class ComponentizedGeneratorsDoNotPassConfigurationOnToComponentsTest {
     public static class BoxOfFoo {
         static int iterations;
 
-        @Theory public void holds(@ForAll @Same(5) Box<Foo> b) {
+        @Theory public void holds(@ForAll @X Box<Foo> b) {
             ++iterations;
 
-            assertNotEquals(5, b.contents().i());
+            assertFalse(b.contents().marked());
         }
     }
 }

--- a/generators/src/test/java/com/pholser/junit/quickcheck/ForAllPrimitiveTheoryParameterTypesTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/ForAllPrimitiveTheoryParameterTypesTest.java
@@ -28,6 +28,7 @@ package com.pholser.junit.quickcheck;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.pholser.junit.quickcheck.generator.GeneratorConfigurationException;
 import com.pholser.junit.quickcheck.generator.InRange;
 import com.pholser.junit.quickcheck.generator.RangeAttributes;
 import com.pholser.junit.quickcheck.generator.ValuesOf;
@@ -710,17 +711,15 @@ public class ForAllPrimitiveTheoryParameterTypesTest {
         }
     }
 
-    @Test public void valuesOfHasNoEffectOnNonBooleanNonEnum() throws Exception {
-        assertThat(testResult(ValuesOfOnInt.class), isSuccessful());
-        assertEquals(Annotations.defaultSampleSize(), ValuesOfOnInt.iterations);
+    @Test public void valuesOfNotApplicableOnNonBooleanNonEnum() throws Exception {
+        assertThat(
+            testResult(ValuesOfOnInt.class),
+            hasSingleFailureContaining(GeneratorConfigurationException.class.getName()));
     }
 
     @RunWith(Theories.class)
     public static class ValuesOfOnInt {
-        static int iterations;
-
         @Theory public void shouldHold(@ForAll @ValuesOf int i) {
-            ++iterations;
         }
     }
 


### PR DESCRIPTION
When generating values for a theory parameter p of type T, annotated with
some set of configuration annotations S, junit-quickcheck used to call
upon all available generators that could produce a T to generate values for
p, silently ignoring the fact that some of those generators might not support
some of the configuration annotations in S.

Now, only those generators that can produce a T *and* support all of the
configuration annotations in S will be called upon thusly.