### PR TITLE
Added shrinking control "maxShrinkTime" for maximum time elapsed

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/Property.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/Property.java
@@ -70,4 +70,10 @@ public @interface Property {
      * {@link #shrink()} is {@code true}.
      */
     int maxShrinkDepth() default 20;
+
+    /**
+     * @return the maximum elapsed time for the shrinking process in
+     * milliseconds; in effect only when {@link #shrink()} is {@code true}.
+     */
+    int maxShrinkTime() default 60_000;
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/ShrinkControl.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/ShrinkControl.java
@@ -29,11 +29,13 @@ public class ShrinkControl {
     private final boolean shouldShrink;
     private final int maxShrinks;
     private final int maxShrinkDepth;
+    private final int maxShrinkTime;
 
-    public ShrinkControl(boolean shouldShrink, int maxShrinks, int maxShrinkDepth) {
+    public ShrinkControl(boolean shouldShrink, int maxShrinks, int maxShrinkDepth, int maxShrinkTime) {
         this.shouldShrink = shouldShrink;
         this.maxShrinks = maxShrinks;
         this.maxShrinkDepth = maxShrinkDepth;
+        this.maxShrinkTime = maxShrinkTime;
     }
 
     public boolean shouldShrink() {
@@ -46,5 +48,9 @@ public class ShrinkControl {
 
     public int maxShrinkDepth() {
         return maxShrinkDepth;
+    }
+
+    public int maxShrinkTime() {
+        return maxShrinkTime;
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
@@ -82,7 +82,8 @@ class PropertyStatement extends Statement {
         ShrinkControl shrinkControl = new ShrinkControl(
             marker.shrink(),
             marker.maxShrinks(),
-            marker.maxShrinkDepth());
+            marker.maxShrinkDepth(),
+            marker.maxShrinkTime());
 
         List<PropertyParameterGenerationContext> params = parameters(trials);
 
@@ -143,7 +144,8 @@ class PropertyStatement extends Statement {
             testClass,
             failure,
             shrinkControl.maxShrinks(),
-            shrinkControl.maxShrinkDepth())
+            shrinkControl.maxShrinkDepth(),
+            shrinkControl.maxShrinkTime())
             .shrink(params, args);
     }
 

--- a/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
@@ -203,4 +203,19 @@ public class ShrinkingTest {
             assertThat(first.i(), lessThan(1));
         }
     }
+
+    @Test public void timeout() throws Exception {
+        assertThat(
+                testResult(ShrinkingTimeout.class),
+                hasSingleFailureContaining("shrunken to ["));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class ShrinkingTimeout {
+        @Property(maxShrinks = Integer.MAX_VALUE, maxShrinkDepth = Integer.MAX_VALUE, maxShrinkTime = 200)
+        public void shouldHold(Foo f) throws InterruptedException {
+            assumeThat(f.slow(), greaterThan(Integer.MAX_VALUE / 2));
+            assertThat(f.slow(), lessThan(Integer.MAX_VALUE / 2));
+        }
+    }
 }

--- a/core/src/test/java/com/pholser/junit/quickcheck/test/generator/Foo.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/test/generator/Foo.java
@@ -42,6 +42,11 @@ public class Foo {
         return i;
     }
 
+    public int slow() throws InterruptedException {
+        Thread.sleep(500);
+        return i;
+    }
+
     public boolean marked() {
         return marked;
     }


### PR DESCRIPTION
Here is a proposed implementation of #75.  I renamed the property to maxShrinkTime to make it more clear that it only controls shrink time, and increased its granularity to milliseconds.

Let me know what you think.  Any suggestions welcome.