### PR TITLE
Optional hook for debugging failing tests

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/DisableOnFailingSetHook.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/DisableOnFailingSetHook.java
@@ -1,8 +1,0 @@
-package com.pholser.junit.quickcheck;
-
-public class DisableOnFailingSetHook implements OnFailingSetHook {
-
-    @Override
-    public void handle(Object[] counterExample) {}
-
-}

--- a/core/src/main/java/com/pholser/junit/quickcheck/DisableOnFailingSetHook.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/DisableOnFailingSetHook.java
@@ -1,0 +1,8 @@
+package com.pholser.junit.quickcheck;
+
+public class DisableOnFailingSetHook implements OnFailingSetHook {
+
+    @Override
+    public void handle(Object[] counterExample) {}
+
+}

--- a/core/src/main/java/com/pholser/junit/quickcheck/OnFailingSetHook.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/OnFailingSetHook.java
@@ -1,0 +1,16 @@
+package com.pholser.junit.quickcheck;
+
+/**
+ * Allows the user to get hold of an actual failing example (useful if the object's
+ * toString representation is difficult to understand).
+ *
+ * To install the hook, overwrite {@link Property#onFailingSet()} for a failing test.
+ */
+public interface OnFailingSetHook {
+
+    /**
+     * @param counterExample the minimal counter example (after shrinking)
+     */
+    void handle(Object[] counterExample);
+
+}

--- a/core/src/main/java/com/pholser/junit/quickcheck/OnFailingSetHook.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/OnFailingSetHook.java
@@ -10,7 +10,9 @@ public interface OnFailingSetHook {
 
     /**
      * @param counterExample the minimal counter example (after shrinking)
+     * @param repeatTestOption allows to repeat the test with the minimal counter example
+     * (can be safely called multiple times)
      */
-    void handle(Object[] counterExample);
+    void handle(Object[] counterExample, Runnable repeatTestOption);
 
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/Property.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/Property.java
@@ -31,6 +31,8 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 
+import com.pholser.junit.quickcheck.hook.DisableOnFailingSetHook;
+
 /**
  * <p>Mark a method on a class that is {@linkplain org.junit.runner.RunWith
  * run with} the {@link com.pholser.junit.quickcheck.runner.JUnitQuickcheck}

--- a/core/src/main/java/com/pholser/junit/quickcheck/Property.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/Property.java
@@ -75,4 +75,10 @@ public @interface Property {
      * milliseconds; in effect only when {@link #shrink()} is {@code true}
      */
     int maxShrinkTime() default 60_000;
+
+    /**
+     * @return callback that it is executed if a minimal counter example is found
+     * (after shrinking)
+     */
+    Class<? extends OnFailingSetHook> onFailingSet() default DisableOnFailingSetHook.class;
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/hook/DisableOnFailingSetHook.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/hook/DisableOnFailingSetHook.java
@@ -1,0 +1,10 @@
+package com.pholser.junit.quickcheck.hook;
+
+import com.pholser.junit.quickcheck.OnFailingSetHook;
+
+public class DisableOnFailingSetHook implements OnFailingSetHook {
+
+    @Override
+    public void handle(Object[] counterExample, Runnable repeatTestOption) {}
+
+}

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/ShrinkControl.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/ShrinkControl.java
@@ -25,17 +25,22 @@
 
 package com.pholser.junit.quickcheck.internal;
 
+import java.util.function.Consumer;
+
 public class ShrinkControl {
     private final boolean shouldShrink;
     private final int maxShrinks;
     private final int maxShrinkDepth;
     private final int maxShrinkTime;
+    private final Consumer<Object[]> onFailingSetHook;
 
-    public ShrinkControl(boolean shouldShrink, int maxShrinks, int maxShrinkDepth, int maxShrinkTime) {
+    public ShrinkControl(boolean shouldShrink, int maxShrinks, int maxShrinkDepth, int maxShrinkTime,
+                         Consumer<Object[]> onFailingSetHook) {
         this.shouldShrink = shouldShrink;
         this.maxShrinks = maxShrinks;
         this.maxShrinkDepth = maxShrinkDepth;
         this.maxShrinkTime = maxShrinkTime;
+        this.onFailingSetHook = onFailingSetHook;
     }
 
     public boolean shouldShrink() {
@@ -52,5 +57,9 @@ public class ShrinkControl {
 
     public int maxShrinkTime() {
         return maxShrinkTime;
+    }
+
+    public Consumer<Object[]> onFailingSetHook() {
+        return onFailingSetHook;
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/ShrinkControl.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/ShrinkControl.java
@@ -25,17 +25,20 @@
 
 package com.pholser.junit.quickcheck.internal;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+
+import com.pholser.junit.quickcheck.OnFailingSetHook;
 
 public class ShrinkControl {
     private final boolean shouldShrink;
     private final int maxShrinks;
     private final int maxShrinkDepth;
     private final int maxShrinkTime;
-    private final Consumer<Object[]> onFailingSetHook;
+    private final OnFailingSetHook onFailingSetHook;
 
     public ShrinkControl(boolean shouldShrink, int maxShrinks, int maxShrinkDepth, int maxShrinkTime,
-                         Consumer<Object[]> onFailingSetHook) {
+                         OnFailingSetHook onFailingSetHook) {
         this.shouldShrink = shouldShrink;
         this.maxShrinks = maxShrinks;
         this.maxShrinkDepth = maxShrinkDepth;
@@ -59,7 +62,7 @@ public class ShrinkControl {
         return maxShrinkTime;
     }
 
-    public Consumer<Object[]> onFailingSetHook() {
+    public OnFailingSetHook onFailingSetHook() {
         return onFailingSetHook;
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
@@ -121,9 +121,9 @@ class PropertyStatement extends Statement {
             args,
             s -> ++successes,
             assumptionViolations::add,
-            e -> {
+            (e, repeatTestOption) -> {
                 if (!shrinkControl.shouldShrink()) {
-                    shrinkControl.onFailingSetHook().accept(args);
+                    shrinkControl.onFailingSetHook().handle(args, repeatTestOption);
                     throw e;
                 }
 

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
@@ -60,6 +60,10 @@ final class ShrinkNode {
         this.depth = depth;
     }
 
+    Object[] getArgs() {
+        return args;
+    }
+
     static ShrinkNode root(
         FrameworkMethod method,
         TestClass testClass,
@@ -116,7 +120,7 @@ final class ShrinkNode {
             args,
             s -> result[0] = true,
             v -> result[0] = true,
-            e -> result[0] = false);
+            (e, repeatTestOption) -> result[0] = false);
     }
 
     private ShrinkNode shrinkNodeFor(Object shrunk) {

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
@@ -27,6 +27,7 @@ package com.pholser.junit.quickcheck.runner;
 
 import java.util.List;
 import java.util.Stack;
+import java.util.function.Consumer;
 
 import com.pholser.junit.quickcheck.internal.generator.PropertyParameterGenerationContext;
 import org.junit.runners.model.FrameworkMethod;
@@ -41,6 +42,7 @@ class Shrinker {
     private final int maxShrinkTime;
     private int shrinkAttempts;
     private long shrinkTimeout;
+    private final Consumer<Object[]> onFailingSetHook;
 
     Shrinker(
         FrameworkMethod method,
@@ -48,7 +50,8 @@ class Shrinker {
         AssertionError failure,
         int maxShrinks,
         int maxShrinkDepth,
-        int maxShrinkTime) {
+        int maxShrinkTime,
+        Consumer<Object[]> onFailingSetHook) {
 
         this.method = method;
         this.testClass = testClass;
@@ -56,6 +59,7 @@ class Shrinker {
         this.maxShrinks = maxShrinks;
         this.maxShrinkDepth = maxShrinkDepth;
         this.maxShrinkTime = maxShrinkTime;
+        this.onFailingSetHook = onFailingSetHook;
     }
 
     void shrink(List<PropertyParameterGenerationContext> params, Object[] args)
@@ -90,6 +94,7 @@ class Shrinker {
             }
         }
 
+        onFailingSetHook.accept(args);
         throw smallestFailure.fail(failure);
     }
 

--- a/core/src/test/java/com/pholser/junit/quickcheck/OnFailingSetHookTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/OnFailingSetHookTest.java
@@ -1,0 +1,120 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2016 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+import static org.junit.experimental.results.PrintableResult.*;
+import static org.junit.experimental.results.ResultMatchers.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import com.pholser.junit.quickcheck.test.generator.Foo;
+
+public class OnFailingSetHookTest {
+
+    public static class StoreFailingSetInGlobalVariableHook implements OnFailingSetHook {
+        static Object[] counterExample = null;
+        static int counter = 0;
+
+        static void reset() {
+            counterExample = null;
+            counter = 0;
+        }
+
+        @Override
+        public void handle(Object[] counterExample) {
+            this.counterExample = counterExample;
+            this.counter++;
+        }
+    }
+
+    @Before public void resetStoreFailingSetInGlobalVariableHook() {
+        StoreFailingSetInGlobalVariableHook.reset();
+    }
+
+    @Test public void shouldNotCallOnFailingSetHookIfTestSucceeds() throws Exception {
+        assumeThat(
+                testResult(SuccessfulTest.class),
+                isSuccessful());
+
+        assertEquals(0, StoreFailingSetInGlobalVariableHook.counter);
+        assertNull(StoreFailingSetInGlobalVariableHook.counterExample);
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class SuccessfulTest {
+        @Property(onFailingSet = StoreFailingSetInGlobalVariableHook.class)
+        public void shouldHold(Foo f) {
+        }
+    }
+
+    @Test public void onFailingSetHookShouldBeCalled() throws Exception {
+        assumeThat(
+                testResult(FailingTestWithShrinking.class),
+                not(isSuccessful()));
+
+        assertEquals(1, StoreFailingSetInGlobalVariableHook.counter);
+        assertNotNull(StoreFailingSetInGlobalVariableHook.counterExample);
+        assertThat(StoreFailingSetInGlobalVariableHook.counterExample, instanceOf(Object[].class));
+        assertEquals(1, StoreFailingSetInGlobalVariableHook.counterExample.length);
+        assertThat(StoreFailingSetInGlobalVariableHook.counterExample[0], instanceOf(Foo.class));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class FailingTestWithShrinking {
+        @Property(onFailingSet = StoreFailingSetInGlobalVariableHook.class)
+        public void shouldHold(Foo f) {
+            assumeThat(f.i(), greaterThan(Integer.MAX_VALUE / 2));
+            assertThat(f.i(), lessThan(Integer.MAX_VALUE / 2));
+        }
+    }
+
+    @Test public void onFailingSetHookShouldBeCalledForFailingTestsWithoutShrinking() throws Exception {
+        assumeThat(
+                testResult(FailingTestWithShrinkingDisabled.class),
+                not(isSuccessful()));
+
+        assertEquals(1, StoreFailingSetInGlobalVariableHook.counter);
+        assertNotNull(StoreFailingSetInGlobalVariableHook.counterExample);
+        assertThat(StoreFailingSetInGlobalVariableHook.counterExample, instanceOf(Object[].class));
+        assertEquals(1, StoreFailingSetInGlobalVariableHook.counterExample.length);
+        assertThat(StoreFailingSetInGlobalVariableHook.counterExample[0], instanceOf(Foo.class));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class FailingTestWithShrinkingDisabled {
+        @Property(onFailingSet = StoreFailingSetInGlobalVariableHook.class, shrink = false)
+        public void shouldHold(Foo f) {
+            assumeThat(f.i(), greaterThan(Integer.MAX_VALUE / 2));
+            assertThat(f.i(), lessThan(Integer.MAX_VALUE / 2));
+        }
+    }
+}


### PR DESCRIPTION
The first patch 1e20ad5 adds the option to execute user-defined code on the minimal counter example.

In the second patch c4d9ad5, there is additionally the option to repeat the failing test with the counter example. For instance, it could be used with a hook like this:

```
public static class RepeatFailingTestForever implements OnFailingSetHook {

        @Override
        public void handle(Object[] counterExample, Runnable repeatTestOption) {
            for (;;) {
                System.out.println("Repeating failing test with input: " + Arrays.deepToString(counterExample));
                repeatTestOption.run();
                try {
                    Thread.sleep(500);
                } catch (InterruptedException e) {
                }
            }
        }
    }
```

To install the hook, you have to overwrite the default hook in the propety (which is just a NOOP):

```
@Property(onFailingSet = RepeatFailingTestForever.class)
```

Another use can could be to serialize the arguments (provided by the ```counterExample``` argument) into a user-specific format, and use it later for regression tests.

Please take a look at the idea. If you want to change any names, please feel free to do that. Maybe there is something better than ```OnFailingSetHook```.
