### PR TITLE
Report parameter seeds in AssertionErrors

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/PropertyParameterGenerationContext.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/PropertyParameterGenerationContext.java
@@ -124,7 +124,7 @@ public class PropertyParameterGenerationContext implements GenerationStatus {
         return successfulEvaluations + discards;
     }
 
-    public long getEffectiveSeed() {
+    public long effectiveSeed() {
         return random.seed();
     }
 

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/PropertyParameterGenerationContext.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/PropertyParameterGenerationContext.java
@@ -124,6 +124,10 @@ public class PropertyParameterGenerationContext implements GenerationStatus {
         return successfulEvaluations + discards;
     }
 
+    public long getEffectiveSeed() {
+        return random.seed();
+    }
+
     public static class DiscardRatioExceededException extends RuntimeException {
         static final String MESSAGE_TEMPLATE =
             "For parameter [%s] with discard ratio [%d], %d unsuccessful values and %d successes"

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
@@ -108,14 +108,14 @@ class PropertyStatement extends Statement {
 
         List<SeededValue> seededValues = argumentsFor(params);
         Object[] args = seededValues.stream().map(v -> v.value).toArray();
-        Long[] seeds = seededValues.stream().map(v -> v.seed).collect(Collectors.toList()).toArray(new Long[args.length]);
+        long[] seeds = seededValues.stream().mapToLong(SeededValue::seed).toArray();
         property(params, args, seeds, shrinkControl).verify();
     }
 
     private PropertyVerifier property(
         List<PropertyParameterGenerationContext> params,
         Object[] args,
-        Long[] initialSeeds,
+        long[] initialSeeds,
         ShrinkControl shrinkControl)
         throws InitializationError {
 
@@ -146,7 +146,7 @@ class PropertyStatement extends Statement {
     private void shrink(
         List<PropertyParameterGenerationContext> params,
         Object[] args,
-        Long[] initialSeeds,
+        long[] initialSeeds,
         ShrinkControl shrinkControl,
         AssertionError failure)
         throws Throwable {
@@ -201,17 +201,25 @@ class PropertyStatement extends Statement {
 
     private List<SeededValue> argumentsFor(List<PropertyParameterGenerationContext> params) {
         return params.stream()
-            .map(p -> new SeededValue(p.generate(), p.getEffectiveSeed()))
+            .map(p -> new SeededValue(p.generate(), p.effectiveSeed()))
             .collect(toList());
     }
 
     private class SeededValue {
-        Object value;
-        Long seed;
+        private Object value;
+        private long seed;
 
-        public SeededValue(Object value, Long seed) {
+        public SeededValue(Object value, long seed) {
             this.value = value;
             this.seed = seed;
+        }
+
+        Object value() {
+            return value;
+        }
+
+        long seed() {
+            return seed;
         }
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyVerifier.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyVerifier.java
@@ -41,7 +41,7 @@ import static java.util.Arrays.*;
 class PropertyVerifier extends BlockJUnit4ClassRunner {
     private final FrameworkMethod method;
     private final Object[] args;
-    private final Long[] initialSeeds;
+    private final long[] initialSeeds;
     private final Consumer<Void> onSuccess;
     private final Consumer<AssumptionViolatedException> onAssumptionViolated;
 
@@ -52,7 +52,7 @@ class PropertyVerifier extends BlockJUnit4ClassRunner {
         TestClass clazz,
         FrameworkMethod method,
         Object[] args,
-        Long[] initialSeeds,
+        long[] initialSeeds,
         Consumer<Void> onSuccess,
         Consumer<AssumptionViolatedException> onAssumptionViolated,
         BiConsumer<AssertionError, Runnable> onFailure)

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyVerifier.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyVerifier.java
@@ -41,6 +41,7 @@ import static java.util.Arrays.*;
 class PropertyVerifier extends BlockJUnit4ClassRunner {
     private final FrameworkMethod method;
     private final Object[] args;
+    private final Long[] initialSeeds;
     private final Consumer<Void> onSuccess;
     private final Consumer<AssumptionViolatedException> onAssumptionViolated;
 
@@ -51,6 +52,7 @@ class PropertyVerifier extends BlockJUnit4ClassRunner {
         TestClass clazz,
         FrameworkMethod method,
         Object[] args,
+        Long[] initialSeeds,
         Consumer<Void> onSuccess,
         Consumer<AssumptionViolatedException> onAssumptionViolated,
         BiConsumer<AssertionError, Runnable> onFailure)
@@ -59,6 +61,7 @@ class PropertyVerifier extends BlockJUnit4ClassRunner {
         super(clazz.getJavaClass());
         this.method = method;
         this.args = args;
+        this.initialSeeds = initialSeeds;
         this.onSuccess = onSuccess;
         this.onAssumptionViolated = onAssumptionViolated;
         this.onFailure = onFailure;
@@ -109,9 +112,10 @@ class PropertyVerifier extends BlockJUnit4ClassRunner {
     private void reportErrorWithArguments(Throwable e) {
         throw new AssertionError(
             String.format(
-                "Unexpected error in property %s with args %s",
+                "Unexpected error in property %s with args %s and initial seeds %s",
                 method.getName(),
-                asList(args)),
+                asList(args),
+                asList(initialSeeds)),
             e);
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
@@ -41,7 +41,7 @@ final class ShrinkNode {
     private final TestClass testClass;
     private final List<PropertyParameterGenerationContext> params;
     private final Object[] args;
-    private final Long[] initialSeeds;
+    private final long[] initialSeeds;
     private final int argIndex;
     private final int depth;
 
@@ -50,7 +50,7 @@ final class ShrinkNode {
         TestClass testClass,
         List<PropertyParameterGenerationContext> params,
         Object[] args,
-        Long[] initialSeeds,
+        long[] initialSeeds,
         int argIndex,
         int depth) {
 
@@ -71,7 +71,8 @@ final class ShrinkNode {
         FrameworkMethod method,
         TestClass testClass,
         List<PropertyParameterGenerationContext> params,
-        Object[] args, Long[] initialSeeds) {
+        Object[] args,
+        long[] initialSeeds) {
 
         return new ShrinkNode(method, testClass, params, args, initialSeeds, 0, 0);
     }

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
@@ -41,6 +41,7 @@ final class ShrinkNode {
     private final TestClass testClass;
     private final List<PropertyParameterGenerationContext> params;
     private final Object[] args;
+    private final Long[] initialSeeds;
     private final int argIndex;
     private final int depth;
 
@@ -49,6 +50,7 @@ final class ShrinkNode {
         TestClass testClass,
         List<PropertyParameterGenerationContext> params,
         Object[] args,
+        Long[] initialSeeds,
         int argIndex,
         int depth) {
 
@@ -56,6 +58,7 @@ final class ShrinkNode {
         this.testClass = testClass;
         this.params = params;
         this.args = args;
+        this.initialSeeds = initialSeeds;
         this.argIndex = argIndex;
         this.depth = depth;
     }
@@ -68,9 +71,9 @@ final class ShrinkNode {
         FrameworkMethod method,
         TestClass testClass,
         List<PropertyParameterGenerationContext> params,
-        Object[] args) {
+        Object[] args, Long[] initialSeeds) {
 
-        return new ShrinkNode(method, testClass, params, args, 0, 0);
+        return new ShrinkNode(method, testClass, params, args, initialSeeds, 0, 0);
     }
 
     List<ShrinkNode> shrinks() {
@@ -92,15 +95,16 @@ final class ShrinkNode {
     }
 
     ShrinkNode advanceToNextArg() {
-        return new ShrinkNode(method, testClass, params, args, argIndex + 1, depth);
+        return new ShrinkNode(method, testClass, params, args, initialSeeds, argIndex + 1, depth);
     }
 
     AssertionError fail(AssertionError originalFailure) {
         AssertionError minimumFailure = new AssertionError(
             String.format(
-                "Property %s falsified for args shrunken to %s",
+                "Property %s falsified for args shrunken to %s using initial seeds %s",
                 method.getName(),
-                asList(args)));
+                asList(args),
+                asList(initialSeeds)));
         minimumFailure.setStackTrace(originalFailure.getStackTrace());
         throw minimumFailure;
     }
@@ -118,6 +122,7 @@ final class ShrinkNode {
             testClass,
             method,
             args,
+            initialSeeds,
             s -> result[0] = true,
             v -> result[0] = true,
             (e, repeatTestOption) -> result[0] = false);
@@ -128,6 +133,6 @@ final class ShrinkNode {
         System.arraycopy(args, 0, shrunkArgs, 0, args.length);
         shrunkArgs[argIndex] = shrunk;
 
-        return new ShrinkNode(method, testClass, params, shrunkArgs, argIndex, depth + 1);
+        return new ShrinkNode(method, testClass, params, shrunkArgs, initialSeeds, argIndex, depth + 1);
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
@@ -63,11 +63,11 @@ class Shrinker {
         this.onFailingSetHook = onFailingSetHook;
     }
 
-    void shrink(List<PropertyParameterGenerationContext> params, Object[] args)
+    void shrink(List<PropertyParameterGenerationContext> params, Object[] args, Long[] initialSeeds)
         throws Throwable {
 
         Stack<ShrinkNode> nodes = new Stack<>();
-        ShrinkNode smallestFailure = ShrinkNode.root(method, testClass, params, args);
+        ShrinkNode smallestFailure = ShrinkNode.root(method, testClass, params, args, initialSeeds);
         smallestFailure.shrinks().forEach(nodes::push);
 
         shrinkTimeout = System.currentTimeMillis() + maxShrinkTime;

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
@@ -63,7 +63,7 @@ class Shrinker {
         this.onFailingSetHook = onFailingSetHook;
     }
 
-    void shrink(List<PropertyParameterGenerationContext> params, Object[] args, Long[] initialSeeds)
+    void shrink(List<PropertyParameterGenerationContext> params, Object[] args, long[] initialSeeds)
         throws Throwable {
 
         Stack<ShrinkNode> nodes = new Stack<>();


### PR DESCRIPTION
This would be a pretty simple way to report seeds by just passing the seeds along with the generated args.

Fixes #92 