### PR TITLE
Muzietto's proposed site pages changes - 2nd attempt

### DIFF
--- a/site/0.6/index.html
+++ b/site/0.6/index.html
@@ -271,11 +271,13 @@
 
     @RunWith(JUnitQuickcheck.class)
     public class StringProperties {
-        @Property public void concatenationLength(String s1, String s2) {
+        @Property
+        public void concatenationLength(String s1, String s2) {
             assertEquals(s1.length() + s2.length(), (s1 + s2).length());
         }
     }
 </pre></div></div></div>
+<p>This test method verifies the property that the length of the sum of two strings is always equal to the sum of the individual string lengths. The properties tested by JUnit-Quickcheck can be expressed through any available JUnit assertion.</p><p/>A JUnit-Quickcheck test method can actually verify multiple properties at a single time. Just write more assertions inside the same method and they will all be verified.</p>
                   </div>
             </div>
           </div>

--- a/site/0.6/usage/basic-types.html
+++ b/site/0.6/usage/basic-types.html
@@ -257,7 +257,7 @@
         <div id="bodyColumn"  class="span10" >
                                   
             <h1>Supported types</h1>
-<p>Out of the box (core + generators), junit-quickcheck recognizes property parameters of the following types:</p>
+<p>Out of the box (core + generators), junit-quickcheck recognizes property test method parameters of the following types:</p>
 
 <ul>
   
@@ -283,7 +283,7 @@
   
 <li>others&#x2026;</li>
 </ul>
-<p>When many generators can satisfy a given property parameter based on its type (for example, <tt>java.io.Serializable</tt>), on a given generation junit-quickcheck will choose one of the multiple generators at random with (roughly) equal probability.</p>
+<p>When many generators can satisfy a given property test parameter based on its type (for example, <tt>java.io.Serializable</tt>), on a given generation junit-quickcheck will choose one of the multiple generators at random with (roughly) equal probability.</p>
                   </div>
             </div>
           </div>

--- a/site/0.6/usage/configuring.html
+++ b/site/0.6/usage/configuring.html
@@ -257,7 +257,8 @@
         <div id="bodyColumn"  class="span10" >
                                   
             <h1>Configuring generators</h1>
-<p>If you mark a property parameter with an annotation that is itself marked as <tt>@GeneratorConfiguration</tt>, then if the <tt>Generator</tt> for that parameter&#x2019;s type has a public method named <tt>configure</tt> that accepts a single argument of the annotation type, JUnit-Quickcheck will call the <tt>configure</tt> method reflectively, passing it the annotation. The call will take place **before** the call to <tt>generate</tt>, ensuring that the configured value will be in position so to influence the behavior of the generator at the next run.</p>
+<p>If you mark a property parameter with an annotation that is itself marked as <tt>@GeneratorConfiguration</tt>, then if the <tt>Generator</tt> for that parameter&#x2019;s type has a public method named <tt>configure</tt> that accepts a single argument of the annotation type, JUnit-Quickcheck will call the <tt>configure</tt> method reflectively, passing it the annotation. 
+The call will take place **before** the call to <tt>generate</tt>, ensuring that the configured value will be in position so to influence the behavior of the generator at the next run.</p>
 
 <div class="source">
 <div class="source"><pre class="prettyprint">    
@@ -266,6 +267,11 @@
 
     public class PositiveGenerator extends Generator&lt;Integer&gt; {
         private Positive positive;
+
+        // NB: every custom generator needs a no-args constructor!
+        public PositiveGenerator() {
+            super(Integer.class);
+        }
 
         @Override
         public Integer generate(
@@ -284,7 +290,7 @@
     @RunWith(JUnitQuickcheck.class)
     public class Numbers {
         @Property
-        public void holds(@Positive int i) {
+        public void holds(@From(positiveGenerator.class) @Positive int i) {
             assertTrue(i > 0);
         }
     }
@@ -296,9 +302,12 @@
 <li>Annotation interface <tt>Positive</tt> is marked as a <tt>@GeneratorConfiguration</tt>.</li>
 <li></li>
 </ol><br/>
-All this leads to JUnit-Quickcheck understanding that the <tt>public Integer generate</tt> method of <tt>PositiveGenerator</tt> class has to be used to generate <tt>Positive</tt> values for the test method <tt>Numbers.holds</tt>.</p>
+<p></p>All this leads to JUnit-Quickcheck understanding that the <tt>public Integer generate</tt> method of <tt>PositiveGenerator</tt> class has to be used to generate <tt>Positive</tt> values for the test method <tt>Numbers.holds</tt>.</p>
+<p>Had we not placed the <tt>@From</tt> annotation in the test method, <tt>PositiveGenerator</tt> would have been added 
+to the list of eligible generators (<tt>Generator<Integer></tt> and <tt>Generator<Number></tt>) and chosen randomically for the task along with the other ones.</p>
 <p>A <tt>Generator</tt> can have many such <tt>configure</tt> methods.</p>
-<p>Please note that the generation mechanism for the Positive interface can be specified and focused also using annotations, as the following "Aggregating configuration" paragraph illustrates.</p>
+<p>Please note that when building custom generators, each class must have a no-args constructor invoking `super()`</p>
+<p>Be aware that the generation mechanism for the Positive interface can be specified and focused also using annotations, as the following "Aggregating configuration" paragraph illustrates.</p>
 
 <div class="section">
 <h2><a name="Configuration_on_type_uses"></a>Configuration on type uses</h2>

--- a/site/0.6/usage/configuring.html
+++ b/site/0.6/usage/configuring.html
@@ -257,20 +257,18 @@
         <div id="bodyColumn"  class="span10" >
                                   
             <h1>Configuring generators</h1>
-<p>If you mark a property parameter with an annotation that is itself marked as <tt>@GeneratorConfiguration</tt>, then if the <tt>Generator</tt> for that parameter&#x2019;s type has a public method named <tt>configure</tt> that accepts a single argument of the annotation type, junit-quickcheck will call the <tt>configure</tt> method reflectively, passing it the annotation:</p>
+<p>If you mark a property parameter with an annotation that is itself marked as <tt>@GeneratorConfiguration</tt>, then if the <tt>Generator</tt> for that parameter&#x2019;s type has a public method named <tt>configure</tt> that accepts a single argument of the annotation type, JUnit-Quickcheck will call the <tt>configure</tt> method reflectively, passing it the annotation. The call will take place **before** the call to <tt>generate</tt>, ensuring that the configured value will be in position so to influence the behavior of the generator at the next run.</p>
 
 <div class="source">
-<div class="source"><pre class="prettyprint">    @Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
-    @Retention(RUNTIME)
+<div class="source"><pre class="prettyprint">    
     @GeneratorConfiguration
-    public @interface Positive {
-        // ...
-    }
+    public @interface Positive {}
 
-    public class IntegralGenerator extends Generator&lt;Integer&gt; {
+    public class PositiveGenerator extends Generator&lt;Integer&gt; {
         private Positive positive;
 
-        @Override public Integer generate(
+        @Override
+        public Integer generate(
             SourceOfRandomness random,
             GenerationStatus status) {
 
@@ -278,18 +276,30 @@
             return positive != null ? Math.abs(value) : value;
         }
 
-        public void configure(Positive positive) {
-            this.positive = positive;
+        public void configure(Positive p) {
+            this.positive = p;
         }
     }
 
     @RunWith(JUnitQuickcheck.class)
     public class Numbers {
-        @Property public void holds(@Positive int i) {
+        @Property
+        public void holds(@Positive int i) {
+            assertTrue(i > 0);
         }
     }
 </pre></div></div>
+<p>Let's illustrate this example by starting from the bottom:
+<ol>
+<li>Test method parameter <tt>i</tt> is marked as having to be <tt>@Positive</tt>, whatever this may mean to the system - of course we'll make sure that this corresponds to generating strictly positive integer values for the test method.</li>
+<li>A class belonging to the JUnit-Quickcheck <tt>Generator</tt> hyerarchy is found on the classpath, and it has a <tt>configure(Positive p)</tt> method.</li>
+<li>Annotation interface <tt>Positive</tt> is marked as a <tt>@GeneratorConfiguration</tt>.</li>
+<li></li>
+</ol><br/>
+All this leads to JUnit-Quickcheck understanding that the <tt>public Integer generate</tt> method of <tt>PositiveGenerator</tt> class has to be used to generate <tt>Positive</tt> values for the test method <tt>Numbers.holds</tt>.</p>
 <p>A <tt>Generator</tt> can have many such <tt>configure</tt> methods.</p>
+<p>Please note that the generation mechanism for the Positive interface can be specified and focused also using annotations, as the following "Aggregating configuration" paragraph illustrates.</p>
+
 <div class="section">
 <h2><a name="Configuration_on_type_uses"></a>Configuration on type uses</h2>
 <p>Configuration annotations that can target type uses will be honored:</p>
@@ -297,7 +307,8 @@
 <div class="source">
 <div class="source"><pre class="prettyprint">    @RunWith(JUnitQuickcheck.class)
     public class PropertiesOfListsOfSingleDigits {
-        @Property public void hold(
+        @Property
+        public void hold(
             List&lt;@InRange(min = &quot;0&quot;, max = &quot;9&quot;) Integer&gt; digits) {
                 // ...
         }
@@ -323,7 +334,8 @@
 <p>Configuration annotations that are directly on a property parameter, and any configuration annotations on annotations that are directly on a property parameter (and so on&#x2026;) are collected to configure the generator(s) for the parameter:</p>
 
 <div class="source">
-<div class="source"><pre class="prettyprint">    @Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
+<div class="source"><pre class="prettyprint">
+    @Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
     @Retention(RUNTIME)
     @From(MoneyGenerator.class)
     @InRange(min = &quot;0&quot;, max = &quot;20&quot;)
@@ -333,7 +345,8 @@
 
     @RunWith(JUnitQuickcheck.class)
     public class Monies {
-        @Property public void hold(@SmallChange BigDecimal d) {
+        @Property
+        public void hold(@SmallChange BigDecimal d) {
             assertEquals(2, d.scale());
             assertThat(
                 d,
@@ -342,7 +355,9 @@
                     lessThanOrEqualTo(new BigDecimal(&quot;20&quot;))));
         }
     }
-</pre></div></div></div>
+</pre></div></div>
+<p>In this code, class <tt>MoneyGenerator extends Generator&lt;BigDecimal&gt;</tt> will obviously need to have a 
+<tt>public BigDecimal generate(SourceOfRandomness r, GenerationStatus s)</tt> method producing small change the way we wish. In case we forget to implement there the control that amount be less or equal than 20, annotation <tt>@InRange</tt> will see to it that no value higher than 20 be fed as a parameter to any JUnit test method that like <tt>Monies.hold</tt> accepts <tt>SmallChange</tt> values as input.</p></div>
                   </div>
             </div>
           </div>

--- a/site/0.6/usage/constraining.html
+++ b/site/0.6/usage/constraining.html
@@ -259,7 +259,7 @@
             <h1>Constraining generated values</h1>
 <div class="section">
 <h2><a name="Assumptions"></a>Assumptions</h2>
-<p>Properties often use <i>assumptions</i> to declare conditions under which they hold:</p>
+<p>JUnit allows to use <i>assumptions</i> to declare conditions under which property assertions hold:</p>
 
 <div class="source">
 <div class="source"><pre class="prettyprint">    @RunWith(JUnitQuickcheck.class)
@@ -293,7 +293,7 @@
         }
     }
 </pre></div></div>
-<p>Sometimes, using assumptions with junit-quickcheck can yield too few values that meet the desired criteria:</p>
+<p>Alas, sometimes using JUnit assumptions with junit-quickcheck can yield too few values that meet the desired criteria:</p>
 
 <div class="source">
 <div class="source"><pre class="prettyprint">    @RunWith(JUnitQuickcheck.class)
@@ -306,10 +306,11 @@
             // ...
         }
     }
-</pre></div></div></div>
+</pre></div></div>
+<p>Usage of JUnit assumptions is therefore discouraged in the JUnit-Quickcheck context, in favour of an own mechanism.</div>
 <div class="section">
 <h2><a name="Generator_configuration_methods"></a>Generator configuration methods</h2>
-<p>Generator configuration methods and annotations can constrain the values that a generator emits. For example, the <tt>@InRange</tt> annotation on property parameters of integral, floating-point, and <tt>Date</tt> types causes the generators for those types to emit values that fall within a configured minimum/maximum:</p>
+<p>JUnit-Quickcheck's own generator configuration methods and annotations can constrain the values that a generator emits. For example, the <tt>@InRange</tt> annotation on property parameters of integral, floating-point, and <tt>Date</tt> types causes the generators for those types to emit values that fall within a configured minimum/maximum:</p>
 
 <div class="source">
 <div class="source"><pre class="prettyprint">    @RunWith(JUnitQuickcheck.class)
@@ -319,11 +320,11 @@
         }
     }
 </pre></div></div>
-<p>Now, the generator will be configured to ensure that every value generated meets the desired criteria &#x2013; no need to express the desired range of values as an assumption.</p></div>
+<p>Now, the generator will be configured to ensure that every value generated meets the desired criteria &#x2013; no need to express the desired range of values as a JUnit assumption.</p></div>
 <div class="section">
-<h2><a name="Configuration_methods_vs._assumptions"></a>Configuration methods vs. assumptions</h2>
-<p>When using assumptions with junit-quickcheck, every value fed to a property parameter counts against the sample size, even if it doesn&#x2019;t pass any assumptions made against it in the property. You could end up with no values passing the assumption.</p>
-<p>Using generator configurations, assumptions aren&#x2019;t very important, if needed at all &#x2013; every value fed to a property parameter counts against the sample size, but will meet some conditions that assumptions would otherwise have tested.</p></div>
+<h2><a name="Configuration_methods_vs._assumptions"></a>Configuration methods vs. JUnit assumptions</h2>
+<p>When using JUnit assumptions with junit-quickcheck, every value fed to a property parameter counts against the sample size, even if it doesn&#x2019;t pass any assumptions made against it in the test method. You could end up with no values passing the assumption only because they were all stopped before verification of the actual property assertion could be attempted.</p>
+<p>Using generator configurations, JUnit assumptions aren&#x2019;t very important, if needed at all &#x2013; every value fed to a property parameter counts against the sample size, but will meet any condition beforehand that assumptions would otherwise have tested.</p></div>
 <div class="section">
 <h2><a name="ValuesOf"></a><tt>ValuesOf</tt></h2>
 <p>You can mark <tt>boolean</tt> and <tt>enum</tt> property parameters with <tt>@ValuesOf</tt> to force the generation to run through every value in the type&#x2019;s domain, instead of choosing an element from the domain at random every time.</p>

--- a/site/0.6/usage/getting-started.html
+++ b/site/0.6/usage/getting-started.html
@@ -260,9 +260,9 @@
 
 <ul>
   
-<li>Create a class to host the properties you want to verify about a part of your system. Mark it with the annotation <tt>@RunWith(JUnitQuickcheck.class)</tt>.</li>
+<li>Create a test class to host the properties you want to verify about a part of your system. Mark it with the annotation <tt>@RunWith(JUnitQuickcheck.class)</tt>.</li>
   
-<li>Add <tt>public</tt> methods with a return type of <tt>void</tt> on your class, to represent the individual properties. Mark each of them with the annotation <tt>@Property</tt>.</li>
+<li>Add the usual <tt>public</tt> test methods with a return type of <tt>void</tt> on your class, to represent the individual properties. Mark each of them with the annotation <tt>@Property</tt>.</li>
   
 <li>Run your class using JUnit. Each of your properties will be verified against several randomly generated values for each of the parameters on the properties&#x2019; methods.</li>
 </ul>
@@ -283,7 +283,7 @@
 
     @RunWith(JUnitQuickcheck.class)
     public class SymmetricKeyCryptographyProperties {
-        @Property public void decryptReversesEncrypt(String plaintext, Key key)
+        @Property public void decryptReversesEncrypt(String plaintext, String key)
             throws Exception {
 
             Crypto crypto = new Crypto();
@@ -297,6 +297,9 @@
         }
     }
 </pre></div></div>
+<p>In this case the property we are verifying is that every text is equal to itself after being encrypted and then decrypted by our custom code. Such properties can be described through any JUnit assertion.</p>
+<p>In this example JUnitQuickcheck will generate random strings for the field <tt>plaintext</tt> using its own string value generation mechanism.
+As far as the custom <tt>Key</tt> class is concerned, it can become a fixed value or you will need to instruct JUnitQuickcheck how to generate random samples of it. This will be explained in the next pages.</p>
 <p>The usual JUnit machinery is honored: <tt>@Before</tt>, <tt>@After</tt>, <tt>@BeforeClass</tt>, <tt>@AfterClass</tt>, <tt>@Rule</tt>. Zero-arg <tt>public</tt> <tt>void</tt> methods annotated with <tt>@Test</tt> will also be run.</p>
                   </div>
             </div>


### PR DESCRIPTION
OK, here are only the 5 relevant files. 

The main reason for this PR is that I am finding it exceedingly difficult to learn the ropes of junit-quickcheck. I have tried to amend the documentation pages by inserting the information that cost me most time to realize on my own, or the code changes that make the examples actually __runnable__.

Along with these changes, I'd recommend to have a good look at all the pages and put there only verified running code as example, possibly with links to full-fledged Java packages with all needed components. I've already reworked inside this PR the solutions you gave to one of the two issues  that I opened last day. The code of the `CoordinatesGenerator` will need its no-args constructor as well.

I don't pretend to have written the perfect user guide to your truly remarkable product.

Given that I don't believe to be too much behind the level of any average property-based testing wannabe practitioner, I hope that reviewing my changes will provide some insight as to where the current documentation may be most sorely unfulfilling. Thank you for your attention.