### PR TITLE
For #99, make original failure the cause of shrinking error

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
@@ -98,15 +98,20 @@ final class ShrinkNode {
         return new ShrinkNode(method, testClass, params, args, initialSeeds, argIndex + 1, depth);
     }
 
-    AssertionError fail(AssertionError originalFailure) {
-        AssertionError minimumFailure = new AssertionError(
+    AssertionError fail(AssertionError originalFailure, Object[] originalArgs) {
+        throw new AssertionError(
             String.format(
-                "Property %s falsified for args shrunken to %s using initial seeds %s",
+                "Property %s falsified.%n"
+                    + "Original failure message: [%s]%n"
+                    + "Original args: %s%n"
+                    + "Args shrunken to: %s%n"
+                    + "Seeds: %s%n",
                 method.getName(),
+                originalFailure.getMessage(),
+                Arrays.toString(originalArgs),
                 Arrays.toString(args),
-                Arrays.toString(initialSeeds)));
-        minimumFailure.setStackTrace(originalFailure.getStackTrace());
-        throw minimumFailure;
+                Arrays.toString(initialSeeds)),
+            originalFailure);
     }
 
     boolean mightBePast(ShrinkNode other) {

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/Shrinker.java
@@ -100,14 +100,15 @@ class Shrinker {
         }
 
         handleMinimalCounterexample(counterexample);
-        throw counterexample.fail(failure);
+        throw counterexample.fail(failure, args);
     }
 
     private void handleMinimalCounterexample(ShrinkNode counterexample) {
         Runnable repeat = () -> {
             try {
                 counterexample.verifyProperty();
-            } catch (Throwable e) {}
+            } catch (Throwable e) {
+            }
         };
 
         onMinimalCounterexample.handle(counterexample.getArgs(), repeat);

--- a/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
@@ -44,7 +44,7 @@ public class ShrinkingTest {
     @Test public void complete() throws Exception {
         assertThat(
             testResult(ShrinkingCompletely.class),
-            hasSingleFailureContaining(String.format("shrunken to [%s]", new Foo(1))));
+            hasSingleFailureContaining(String.format("Args shrunken to: [%s]", new Foo(1))));
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -60,7 +60,7 @@ public class ShrinkingTest {
     @Test public void partial() throws Exception {
         assertThat(
             testResult(ShrinkingPartially.class),
-            hasSingleFailureContaining("shrunken to ["));
+            hasSingleFailureContaining("Args shrunken to: ["));
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -75,7 +75,7 @@ public class ShrinkingTest {
     @Test public void assumptionFailureWhileShrinking() {
         assertThat(
             testResult(FailedAssumptionDuringShrinking.class),
-            hasSingleFailureContaining("shrunken to ["));
+            hasSingleFailureContaining("Args shrunken to: ["));
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -190,7 +190,7 @@ public class ShrinkingTest {
         assertThat(
             testResult(ShrinkingMoreThanOnePropertyParameter.class),
             hasSingleFailureContaining(
-                String.format("shrunken to [%s, %s]", new Foo(1), new Foo(1))));
+                String.format("Args shrunken to: [%s, %s]", new Foo(1), new Foo(1))));
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -206,8 +206,8 @@ public class ShrinkingTest {
 
     @Test public void timeout() throws Exception {
         assertThat(
-                testResult(ShrinkingTimeout.class),
-                hasSingleFailureContaining("shrunken to ["));
+            testResult(ShrinkingTimeout.class),
+            hasSingleFailureContaining("Args shrunken to: ["));
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
When a property fails, and shrinking kicks in, the reported assertion error
used to have the shrinking message, but the stack trace of the failure
that caused shrinking to occur. Now, the "top-level" assertion error is
the one raised by the shrinker, its stack trace is preserved, and the
assertion error that caused shrinking to happen in the first place is
embedded as the "cause" of the top-level error. That way, we have more
information about the failure.