### PR TITLE
Give more useful look into primitive arrays

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyFalsified.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyFalsified.java
@@ -67,8 +67,8 @@ class PropertyFalsified {
                     + "Seeds: %s%n",
                 propertyName,
                 originalFailure.getMessage(),
-                Arrays.toString(originalArgs),
-                Arrays.toString(args),
+                Arrays.deepToString(originalArgs),
+                Arrays.deepToString(args),
                 Arrays.toString(seeds)),
             originalFailure);
     }


### PR DESCRIPTION
Currently, if you give a test primitive arrays as parameters, when there's an error the error message is less-than-useful `Args shrunken to: [[I@93842]` or similar. I.e. the default toString for primitive arrays.

Calling `Arrays.deepToString` makes such errors more usable.