### PR TITLE
For #120, replace javafx.util.Pair with homegrown

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/Pair.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/Pair.java
@@ -1,0 +1,57 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2016 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck;
+
+import java.util.Objects;
+
+public final class Pair<F, S> {
+    public final F first;
+    public final S second;
+
+    public Pair(F first, S second) {
+        this.first = first;
+        this.second = second;
+    }
+
+    @Override public int hashCode() {
+        return Objects.hash(first, second);
+    }
+
+    @Override public boolean equals(Object o) {
+        if (o == this)
+            return true;
+        if (!(o instanceof Pair<?, ?>))
+            return false;
+
+        Pair<?, ?> other = (Pair<?, ?>) o;
+        return Objects.equals(first, other.first)
+            && Objects.equals(second, other.second);
+    }
+
+    @Override public String toString() {
+        return String.format("[%s = %s]", first, second);
+    }
+}

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Gen.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Gen.java
@@ -33,10 +33,10 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
+import com.pholser.junit.quickcheck.Pair;
 import com.pholser.junit.quickcheck.internal.Items;
 import com.pholser.junit.quickcheck.internal.Weighted;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
-import javafx.util.Pair;
 
 /**
  * Represents a strategy for generating random values.
@@ -180,7 +180,7 @@ public interface Gen<T> {
 
         List<Weighted<Gen<? extends U>>> weighted =
             pairs.stream()
-                .map(p -> new Weighted<Gen<? extends U>>(p.getValue(), p.getKey()))
+                .map(p -> new Weighted<Gen<? extends U>>(p.second, p.first))
                 .collect(Collectors.toList());
 
         return (random, status) ->

--- a/core/src/test/java/com/pholser/junit/quickcheck/PairTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PairTest.java
@@ -1,0 +1,46 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2016 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck;
+
+import com.google.common.testing.EqualsTester;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PairTest {
+    @Test public void equalsHash() {
+        new EqualsTester()
+            .addEqualityGroup(new Pair<>(1, 2), new Pair<>(1, 2))
+            .addEqualityGroup(new Pair<>(null, 3), new Pair<>(null, 3))
+            .addEqualityGroup(new Pair<>(4, null), new Pair<>(4, null))
+            .addEqualityGroup(new Pair<>(null, null), new Pair<>(null, null))
+            .testEquals();
+    }
+
+    @Test public void stringifying() {
+        assertEquals("[1 = 2]", new Pair<>(1, 2).toString());
+    }
+}


### PR DESCRIPTION
The javafx Pair is unavailable in OpenJDK. This hurts Linux users.