### PR TITLE
Avoid BigInteger computation in Ranges#choose when dealing with longs

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/random/SourceOfRandomness.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/random/SourceOfRandomness.java
@@ -241,7 +241,7 @@ public class SourceOfRandomness {
         if (comparison == 0)
             return min;
 
-        return Ranges.choose(this, BigInteger.valueOf(min), BigInteger.valueOf(max)).longValue();
+        return Ranges.choose(this, min, max);
     }
 
     /**

--- a/core/src/test/java/com/pholser/junit/quickcheck/internal/RangesTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/internal/RangesTest.java
@@ -1,0 +1,77 @@
+/*
+ The MIT License
+
+ Copyright (c) 2004-2016 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.pholser.junit.quickcheck.internal;
+
+import static com.pholser.junit.quickcheck.internal.Ranges.findNextPowerOfTwoLong;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+
+import org.junit.Test;
+
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class RangesTest {
+
+    @Test public void checkFindNextPowerOfTwoLong() {
+        assertEquals(1, findNextPowerOfTwoLong(1));
+        assertEquals(2, findNextPowerOfTwoLong(2));
+        assertEquals(4, findNextPowerOfTwoLong(3));
+        assertEquals(4, findNextPowerOfTwoLong(4));
+        assertEquals(8, findNextPowerOfTwoLong(5));
+        assertEquals((long) 1 << 61, findNextPowerOfTwoLong((long) 1 << 61));
+        assertEquals((long) 1 << 62, findNextPowerOfTwoLong(1 + (long) 1 << 61));
+    }
+
+    @Test public void chooseLongsMustReturnValuesInTheExpectedRange() {
+        chooseLongsShouldOnlyReturnValuesInTheExpectedRange(-10L, 100L);
+        chooseLongsShouldOnlyReturnValuesInTheExpectedRange(1L, 1L);
+        chooseLongsShouldOnlyReturnValuesInTheExpectedRange(Long.MIN_VALUE, Long.MIN_VALUE + 1);
+        chooseLongsShouldOnlyReturnValuesInTheExpectedRange(Long.MAX_VALUE - 1, Long.MAX_VALUE);
+        chooseLongsShouldOnlyReturnValuesInTheExpectedRange(Long.MIN_VALUE, Long.MAX_VALUE);
+    }
+
+    private void chooseLongsShouldOnlyReturnValuesInTheExpectedRange(long min, long max) {
+        SourceOfRandomness random = new SourceOfRandomness(new Random(0));
+        for (int i = 0; i < 1000; i++) {
+            long result = Ranges.choose(random, min, max);
+            assertTrue(min <= result && result <= max);
+        }
+    }
+
+    @Test public void weakSanityCheckForDistributionOfChooseLongs() {
+        boolean[] hits = new boolean[5];
+        SourceOfRandomness random = new SourceOfRandomness(new Random(0));
+
+        for (int i = 0; i < 100; i++) {
+            hits[(int) Ranges.choose(random, 0, (long) hits.length - 1)] = true;
+        }
+        for (boolean hit : hits) {
+            assertTrue(hit);
+        }
+    }
+}


### PR DESCRIPTION
Generating random ints and longs is the major bottleneck
(at least in the execution of my quickcheck tests). So, with this change,
I saw an overall speedup of about 2x-3x.

This is not a patch to add functionality or make the code more readable.
I would recommend to critically measure yourself whether you can reproduce
the speedups. For my workloads, they are significant.

As a second baseline, I also plugged in the implementation found in
ThreadLocalRandom#internalNextLong. At least in my test scenarios,
I did not notice an overall speedup in comparison to my version. I get
about the same overall speedup (2x-3x).

On a microlevel, I would expect the JDK version to be faster and it does not
have the "slow path" that my version has. Overall, it does not seem to make a
significant differences when running complete tests.
Also the JDK code is licenced under the GPL, as far as I know.