### PR TITLE
For #136, support contract tests via i/f default methods

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>org.javaruntype</groupId>
             <artifactId>javaruntype</artifactId>
-            <version>1.2</version>
+            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>ognl</groupId>

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheck.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheck.java
@@ -39,6 +39,7 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
+import org.junit.runners.model.TestClass;
 
 /**
  * <p>JUnit test runner for junit-quickcheck property-based tests.</p>
@@ -93,5 +94,9 @@ public class JUnitQuickcheck extends BlockJUnit4ClassRunner {
         return method.getAnnotation(Test.class) != null
             ? super.methodBlock(method)
             : new PropertyStatement(method, getTestClass(), repo, distro);
+    }
+
+    @Override protected TestClass createTestClass(Class<?> testClass) {
+        return new JUnitQuickcheckTestClass(testClass);
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheckTestClass.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheckTestClass.java
@@ -1,0 +1,66 @@
+package com.pholser.junit.quickcheck.runner;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.internal.MethodSorter;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
+
+import static java.util.stream.Collectors.*;
+
+class JUnitQuickcheckTestClass extends TestClass {
+    JUnitQuickcheckTestClass(Class<?> testClass) {
+        super(testClass);
+    }
+
+    @Override
+    protected void scanAnnotatedMembers(
+        Map<Class<? extends Annotation>, List<FrameworkMethod>> methodsForAnnotations,
+        Map<Class<? extends Annotation>, List<FrameworkField>> fieldsForAnnotations) {
+
+        super.scanAnnotatedMembers(methodsForAnnotations, fieldsForAnnotations);
+
+        addDefaultInterfaceMethods(methodsForAnnotations);
+    }
+
+    private void addDefaultInterfaceMethods(
+        Map<Class<? extends Annotation>, List<FrameworkMethod>> methodsForAnnotations) {
+
+        for (Class<?> each : implementedInterfaces()) {
+            addDefaultInterfaceMethodsFrom(methodsForAnnotations, each);
+        }
+    }
+
+    private void addDefaultInterfaceMethodsFrom(
+        Map<Class<? extends Annotation>, List<FrameworkMethod>> methodsForAnnotations,
+        Class<?> iface) {
+
+        List<Method> defaultMethods =
+            Arrays.stream(MethodSorter.getDeclaredMethods(iface))
+                .filter(Method::isDefault)
+                .collect(toList());
+
+        for (Method each : defaultMethods) {
+            addToAnnotationLists(
+                new FrameworkMethod(each),
+                methodsForAnnotations);
+        }
+    }
+
+    private Set<Class<?>> implementedInterfaces() {
+        Set<Class<?>> interfaces = new HashSet<>();
+
+        for (Class<?> c = getJavaClass(); c != null; c = c.getSuperclass())
+            Collections.addAll(interfaces, c.getInterfaces());
+
+        return interfaces;
+    }
+}

--- a/generators/src/test/java/com/pholser/junit/quickcheck/ComparableWithConsistentEqualsContract.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/ComparableWithConsistentEqualsContract.java
@@ -1,0 +1,16 @@
+package com.pholser.junit.quickcheck;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+public interface ComparableWithConsistentEqualsContract<T extends Comparable<T>> {
+    @Property default void equalsConsistency(T thing) {
+        T other = thingComparableTo(thing);
+        assumeThat(thing.compareTo(other), equalTo(0));
+
+        assertEquals(thing, other);
+    }
+
+    T thingComparableTo(T thing);
+}

--- a/generators/src/test/java/com/pholser/junit/quickcheck/ComparatorContract.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/ComparatorContract.java
@@ -1,0 +1,19 @@
+package com.pholser.junit.quickcheck;
+
+import java.util.Comparator;
+
+import static java.lang.Math.*;
+import static org.junit.Assert.*;
+
+public interface ComparatorContract<T> {
+    Comparator<T> getComparator();
+
+    @Property default void symmetry(T x, T y) {
+        Comparator<T> comparator = getComparator();
+
+        assertEquals(
+            signum(comparator.compare(x, y)),
+            -signum(comparator.compare(y, x)),
+            0F);
+    }
+}

--- a/generators/src/test/java/com/pholser/junit/quickcheck/IntegerComparableTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/IntegerComparableTest.java
@@ -1,0 +1,13 @@
+package com.pholser.junit.quickcheck;
+
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitQuickcheck.class)
+public class IntegerComparableTest
+    implements ComparableWithConsistentEqualsContract<Integer> {
+
+    @Override public Integer thingComparableTo(Integer thing) {
+        return thing;
+    }
+}

--- a/generators/src/test/java/com/pholser/junit/quickcheck/IntegerComparatorTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/IntegerComparatorTest.java
@@ -1,0 +1,13 @@
+package com.pholser.junit.quickcheck;
+
+import java.util.Comparator;
+
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitQuickcheck.class)
+public class IntegerComparatorTest<T> implements ComparatorContract<Integer> {
+    @Override public Comparator<Integer> getComparator() {
+        return Integer::compare;
+    }
+}


### PR DESCRIPTION
Needed a correction to javaruntype to handle self-referential generics
bounds (1.3).