### PR TITLE
pom: Use ognl with modern javassist

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>ognl</groupId>
             <artifactId>ognl</artifactId>
-            <version>3.1.2</version>
+            <version>3.1.12</version>
         </dependency>
         <dependency>
             <groupId>ru.vyarus</groupId>


### PR DESCRIPTION
ognl 3.1.2 pulled in an old version av javassist that clashes with PowerMock.