### PR TITLE
For #144, handle array types as type parms on contract tests

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/ParameterTypeContext.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/ParameterTypeContext.java
@@ -240,7 +240,7 @@ public class ParameterTypeContext {
     public ParameterTypeContext arrayComponentContext() {
         @SuppressWarnings("unchecked")
         org.javaruntype.type.Type<?> component = arrayComponentOf((org.javaruntype.type.Type<Object[]>) token);
-        AnnotatedType annotatedComponent = ((AnnotatedArrayType) parameterType).getAnnotatedGenericComponentType();
+        AnnotatedType annotatedComponent = annotatedArrayComponent(component);
         return new ParameterTypeContext(
             annotatedComponent.getType().getTypeName(),
             annotatedComponent,
@@ -249,6 +249,12 @@ public class ParameterTypeContext {
             typeVariables)
             .annotate(annotatedComponent)
             .allowMixedTypes(true);
+    }
+
+    private AnnotatedType annotatedArrayComponent(org.javaruntype.type.Type<?> component) {
+        return parameterType instanceof AnnotatedArrayType
+            ? ((AnnotatedArrayType) parameterType).getAnnotatedGenericComponentType()
+            : FakeAnnotatedTypeFactory.makeFrom(component.getComponentClass());
     }
 
     public Class<?> getRawClass() {

--- a/generators/src/test/java/com/pholser/junit/quickcheck/ContractTestWithArrayTypeParameterTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/ContractTestWithArrayTypeParameterTest.java
@@ -1,0 +1,50 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2016 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck;
+
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.*;
+import static org.junit.experimental.results.ResultMatchers.*;
+
+public class ContractTestWithArrayTypeParameterTest {
+    @Test public void gitHubIssue144() {
+        assertThat(testResult(ArrayTest.class), isSuccessful());
+    }
+
+    public interface ContractTest<T> {
+        @Property default void testProperty(T value) {
+            assertTrue(true);
+        }
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class ArrayTest implements ContractTest<byte[]> {
+    }
+}


### PR DESCRIPTION
This is a little punt-y, and perhaps corner-case-y to begin with.
At the very least, the minimal test case supplied with the issue now
passes.

Over time, we'll have to decide how or if at all to handle annotations
on type parameters in contract tests.