### PR TITLE
For #172, Ctor and Fields now registerable

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Ctor.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Ctor.java
@@ -96,6 +96,10 @@ public class Ctor<T> extends Generator<T> {
             parameterGenerators.get(i).configure(parameters[i].getAnnotatedType());
     }
 
+    @Override public Ctor<T> copy() {
+        return new Ctor<>(ctor);
+    }
+
     private Object[] arguments(SourceOfRandomness random, GenerationStatus status) {
         Object[] args = new Object[parameters.length];
 

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Ctor.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Ctor.java
@@ -81,10 +81,6 @@ public class Ctor<T> extends Generator<T> {
         return instantiate(ctor, arguments(random, status));
     }
 
-    @Override public boolean canRegisterAsType(Class<?> type) {
-        return false;
-    }
-
     @Override public void provide(Generators provided) {
         super.provide(provided);
 

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Fields.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Fields.java
@@ -102,4 +102,8 @@ public class Fields<T> extends Generator<T> {
         for (int i = 0; i < fields.size(); ++i)
             fieldGenerators.get(i).configure(fields.get(i).getAnnotatedType());
     }
+
+    @Override public Generator<T> copy() {
+        return new Fields<>(types().get(0));
+    }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Fields.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Fields.java
@@ -88,10 +88,6 @@ public class Fields<T> extends Generator<T> {
         return type.cast(generated);
     }
 
-    @Override public boolean canRegisterAsType(Class<?> type) {
-        return false;
-    }
-
     @Override public void provide(Generators provided) {
         super.provide(provided);
 

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Generator.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Generator.java
@@ -271,6 +271,16 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
     }
 
     /**
+     * Used by the framework to make a copy of the receiver.
+     *
+     * @return a copy of the receiver
+     */
+    @SuppressWarnings("unchecked")
+    public Generator<T> copy() {
+        return (Generator<T>) instantiate(getClass());
+    }
+
+    /**
      * @return an access point for the available generators
      */
     protected Generators gen() {

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/GeneratorRepository.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/GeneratorRepository.java
@@ -106,11 +106,8 @@ public class GeneratorRepository implements Generators {
         Class<?> type,
         Generator<?> generator) {
 
-        Set<Generator<?>> forType = generators.get(type);
-        if (forType == null) {
-            forType = new LinkedHashSet<>();
-            generators.put(type, forType);
-        }
+        Set<Generator<?>> forType =
+            generators.computeIfAbsent(type, k -> new LinkedHashSet<>());
 
         forType.add(generator);
     }
@@ -222,12 +219,8 @@ public class GeneratorRepository implements Generators {
     }
 
     public Generator<?> generatorFor(ParameterTypeContext parameter) {
-
-        // test for only/also here, wrap the chosen generator in the only/also strategy?
-
         if (!parameter.explicitGenerators().isEmpty())
             return composeWeighted(parameter, parameter.explicitGenerators());
-
         if (parameter.isArray())
             return generatorForArrayType(parameter);
         if (parameter.isEnum())
@@ -350,16 +343,12 @@ public class GeneratorRepository implements Generators {
 
         List<Generator<?>> copies = new ArrayList<>();
         for (Generator<?> each : matches)
-            copies.add(copyOf(each));
+            copies.add(each.copy());
         return copies;
     }
 
     private boolean hasGeneratorsFor(ParameterTypeContext parameter) {
         return generators.get(parameter.getRawClass()) != null;
-    }
-
-    private static Generator<?> copyOf(Generator<?> generator) {
-        return instantiate(generator.getClass());
     }
 
     private static org.javaruntype.type.Type<?> token(Type type) {

--- a/core/src/test/java/com/pholser/junit/quickcheck/PropertyParameterGenerationByConstructorTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PropertyParameterGenerationByConstructorTest.java
@@ -31,7 +31,6 @@ import java.lang.annotation.Target;
 import com.pholser.junit.quickcheck.generator.Ctor;
 import com.pholser.junit.quickcheck.internal.ReflectionException;
 import com.pholser.junit.quickcheck.internal.Zilch;
-import com.pholser.junit.quickcheck.internal.generator.GeneratorRepository;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import com.pholser.junit.quickcheck.test.generator.AnInt;
 import com.pholser.junit.quickcheck.test.generator.Between;
@@ -44,7 +43,6 @@ import org.junit.experimental.results.PrintableResult;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import static com.pholser.junit.quickcheck.Types.*;
 import static com.pholser.junit.quickcheck.test.generator.AFoo.*;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
@@ -119,15 +117,6 @@ public class PropertyParameterGenerationByConstructorTest {
         public Foo f() {
             return f;
         }
-    }
-
-    @Test public void autoGeneratorDoesNotAllowItselfToBeRegistered() throws Exception {
-        GeneratorRepository repo = new GeneratorRepository(null);
-
-        repo.register(new Ctor<>(Object.class));
-
-        thrown.expect(IllegalArgumentException.class);
-        repo.generatorFor(typeOf(getClass(), "object"));
     }
 
     @Test public void autoGenerationOnPrimitiveType() {

--- a/core/src/test/java/com/pholser/junit/quickcheck/PropertyParameterGenerationByFieldsTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PropertyParameterGenerationByFieldsTest.java
@@ -31,7 +31,6 @@ import java.lang.annotation.Target;
 import com.pholser.junit.quickcheck.generator.Fields;
 import com.pholser.junit.quickcheck.internal.ReflectionException;
 import com.pholser.junit.quickcheck.internal.Zilch;
-import com.pholser.junit.quickcheck.internal.generator.GeneratorRepository;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
 import com.pholser.junit.quickcheck.test.generator.AFoo.Same;
 import com.pholser.junit.quickcheck.test.generator.AnInt;
@@ -45,7 +44,6 @@ import org.junit.experimental.results.PrintableResult;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 
-import static com.pholser.junit.quickcheck.Types.*;
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
 import static org.hamcrest.Matchers.*;
@@ -86,15 +84,6 @@ public class PropertyParameterGenerationByFieldsTest {
     }
 
     public static class FakeList<T> {
-    }
-
-    @Test public void autoGeneratorDoesNotAllowItselfToBeRegistered() throws Exception {
-        GeneratorRepository repo = new GeneratorRepository(null);
-
-        repo.register(new Fields<>(Object.class));
-
-        thrown.expect(IllegalArgumentException.class);
-        repo.generatorFor(typeOf(getClass(), "object"));
     }
 
     @Test public void autoGenerationOnPrimitiveType() {

--- a/generators/pom.xml
+++ b/generators/pom.xml
@@ -94,7 +94,7 @@
             <plugin>
                 <groupId>eu.somatik.serviceloader-maven-plugin</groupId>
                 <artifactId>serviceloader-maven-plugin</artifactId>
-                <version>1.0.6</version>
+                <version>1.0.7</version>
                 <configuration>
                     <services>
                         <param>com.pholser.junit.quickcheck.generator.Generator</param>


### PR DESCRIPTION
This will be useful for users that are explicitly manipulating their
own `GeneratorRepository`. These generators already do not get included
in the service loader manifest in junit-quickcheck-core.