### PR TITLE
Ignore shrinks that are equal to "larger"

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/ShrinkNode.java
@@ -88,6 +88,7 @@ final class ShrinkNode {
 
         PropertyParameterGenerationContext param = params.get(argIndex);
         return param.shrink(args[argIndex]).stream()
+            .filter(s -> !s.equals(args[argIndex]))
             .map(this::shrinkNodeFor)
             .collect(Collectors.toList());
     }

--- a/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ShrinkingTest.java
@@ -30,6 +30,7 @@ import java.util.List;
 
 import com.pholser.junit.quickcheck.generator.Size;
 import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import com.pholser.junit.quickcheck.test.generator.AFooBadShrinks;
 import com.pholser.junit.quickcheck.test.generator.Foo;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -69,6 +70,19 @@ public class ShrinkingTest {
             assumeThat(f.i(), greaterThan(Integer.MAX_VALUE / 2));
 
             assertThat(f.i(), lessThan(Integer.MAX_VALUE / 2));
+        }
+    }
+
+    @Test public void shrinkingDoesNotShrinkWhenLargerEqualsSmaller() throws Exception {
+        assertThat(
+            testResult(ShrinksAreIdentity.class),
+            hasSingleFailureContaining("Args: ["));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class ShrinksAreIdentity {
+        @Property public void shouldHold(@From(AFooBadShrinks.class) Foo f) {
+            fail();
         }
     }
 

--- a/core/src/test/java/com/pholser/junit/quickcheck/test/generator/AFooBadShrinks.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/test/generator/AFooBadShrinks.java
@@ -1,0 +1,48 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2017 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.test.generator;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class AFooBadShrinks extends Generator<Foo> {
+
+    public AFooBadShrinks() {
+        super(Foo.class);
+    }
+
+    @Override public Foo generate(SourceOfRandomness random, GenerationStatus status) {
+        return new Foo(random.nextInt());
+    }
+
+    @Override public List<Foo> doShrink(SourceOfRandomness random, Foo larger) {
+        return Collections.singletonList(new Foo(larger.i(), larger.marked()));
+    }
+}

--- a/src/site/markdown/usage/shrinking.md
+++ b/src/site/markdown/usage/shrinking.md
@@ -95,7 +95,6 @@ Your custom generators can, of course, do the same.
                     new Point(larger.x / 2, larger.y),
                     new Point(larger.x, larger.y / 2))
                 .distinct()
-                .filter(p -> !p.equals(larger))
                 .collect(Collectors.toList());
         }
     }


### PR DESCRIPTION
Some "natural" shrinking implementations can lead to retrying the same shrink many times. For example, shrinking a Point (x, y) into:

(x/2, y)
(0, y)
(x, y/2)
(x, 0)

results in many unnecessary shrinks if equals is not checked and one of x or y is much larger than the other.