### PR TITLE
For #190, trap org.junit.internal.AssumptionViolatedException

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyStatement.java
@@ -47,7 +47,7 @@ import com.pholser.junit.quickcheck.internal.generator.PropertyParameterGenerati
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 import com.pholser.junit.quickcheck.internal.sampling.ExhaustiveParameterSampler;
 import com.pholser.junit.quickcheck.internal.sampling.TupleParameterSampler;
-import org.junit.AssumptionViolatedException;
+import org.junit.internal.AssumptionViolatedException;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyVerifier.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/PropertyVerifier.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
-import org.junit.AssumptionViolatedException;
+import org.junit.internal.AssumptionViolatedException;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;


### PR DESCRIPTION
Some assertion libraries still emit this exception, the parent of the
now-published org.junit.AssumptionViolatedException. To support these
libraries, junit-quickcheck will trap the parent exception.