### PR TITLE
Enable distinct array/Collection/Map generation (@Distinct)

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Distinct.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Distinct.java
@@ -1,0 +1,24 @@
+package com.pholser.junit.quickcheck.generator;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * <p>Mark a parameter of a {@link com.pholser.junit.quickcheck.Property}
+ * method with this annotation to make values generated for the parameter
+ * distinct from each other.</p>
+ *
+ * <p>This annotation is recognized on array parameters and parameters of type
+ * {@link java.util.Collection} and {@link java.util.Map}.</p>
+ *
+ * <p>Using this annotation with {@link Size} on {@link java.util.Set} or
+ * {@link java.util.Map} leads to strict size constraint.</p>
+ */
+@Target({ PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE })
+@Retention(RUNTIME)
+@GeneratorConfiguration
+public @interface Distinct {
+}

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/Lists.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/Lists.java
@@ -26,6 +26,7 @@
 package com.pholser.junit.quickcheck.internal;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 
 import com.pholser.junit.quickcheck.generator.Shrink;
@@ -99,5 +100,9 @@ public final class Lists {
                 .collect(toList()));
 
         return shrinks;
+    }
+
+    public static <T> boolean isDistinct(List<T> list) {
+        return new HashSet<>(list).size() == list.size();
     }
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/ArrayGenerator.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/ArrayGenerator.java
@@ -30,14 +30,13 @@ import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
-import com.pholser.junit.quickcheck.generator.GenerationStatus;
-import com.pholser.junit.quickcheck.generator.Generator;
-import com.pholser.junit.quickcheck.generator.Generators;
-import com.pholser.junit.quickcheck.generator.Shrink;
-import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.generator.*;
+import com.pholser.junit.quickcheck.internal.Lists;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static java.math.BigDecimal.*;
@@ -55,6 +54,7 @@ public class ArrayGenerator extends Generator<Object> {
     private final Generator<?> component;
 
     private Size lengthRange;
+    private boolean distinct = false;
 
     public ArrayGenerator(Class<?> componentType, Generator<?> component) {
         super(Object.class);
@@ -74,12 +74,27 @@ public class ArrayGenerator extends Generator<Object> {
         checkRange(INTEGRAL, size.min(), size.max());
     }
 
+    /**
+     * Tells this generator to produce values which are distinct from each other.
+     *
+     * @param distinct Generated values will be distinct if this param is not null.
+     */
+    public void configure(Distinct distinct) {
+        this.distinct = distinct != null;
+    }
+
     @Override public Object generate(SourceOfRandomness random, GenerationStatus status) {
         int length = length(random, status);
         Object array = Array.newInstance(componentType, length);
 
+        Stream<?> itemStream = Stream.generate(() -> component.generate(random, status)).sequential();
+        if (distinct) {
+            itemStream = itemStream.distinct();
+        }
+
+        Iterator<?> iterator = itemStream.iterator();
         for (int i = 0; i < length; ++i)
-            Array.set(array, i, component.generate(random, status));
+            Array.set(array, i, iterator.next());
 
         return array;
     }
@@ -98,8 +113,11 @@ public class ArrayGenerator extends Generator<Object> {
         shrinks.addAll(removals(asList));
 
         @SuppressWarnings("unchecked")
-        List<List<Object>> oneItemShrinks = shrinksOfOneItem(random, asList, (Shrink<Object>) component);
-        shrinks.addAll(oneItemShrinks.stream()
+        Stream<List<Object>> oneItemShrinks = shrinksOfOneItem(random, asList, (Shrink<Object>) component).stream();
+        if (distinct) {
+            oneItemShrinks = oneItemShrinks.filter(Lists::isDistinct);
+        }
+        shrinks.addAll(oneItemShrinks
             .map(this::convert)
             .filter(this::inLengthRange)
             .collect(toList()));

--- a/generators/src/test/java/com/pholser/junit/quickcheck/DistinctArrayPropertyParameterTypesTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/DistinctArrayPropertyParameterTypesTest.java
@@ -1,0 +1,50 @@
+package com.pholser.junit.quickcheck;
+
+import com.google.common.primitives.Ints;
+import com.pholser.junit.quickcheck.generator.Distinct;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.internal.Lists;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.*;
+import static org.junit.experimental.results.ResultMatchers.*;
+
+public class DistinctArrayPropertyParameterTypesTest {
+    @Test public void distinctArrays() {
+        assertThat(testResult(DistinctArrays.class), isSuccessful());
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class DistinctArrays {
+        @Property public void shouldHold(
+            @InRange(minInt = 1, maxInt = 5)int @Size(min = 2, max = 5) @Distinct [] i) {
+            assertThat(i.length, allOf(greaterThanOrEqualTo(2), lessThanOrEqualTo(5)));
+            assertThat(Lists.isDistinct(Ints.asList(i)), is(true));
+        }
+    }
+
+    @Test public void shrinkingDistinctArrays() {
+        assertThat(testResult(ShrinkingDistinctArrays.class), failureCountIs(1));
+        assertThat(
+            ShrinkingDistinctArrays.failed.length,
+            allOf(greaterThanOrEqualTo(4), lessThanOrEqualTo(5)));
+        assertThat(Lists.isDistinct(Ints.asList(ShrinkingDistinctArrays.failed)), is(true));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class ShrinkingDistinctArrays {
+        static int[] failed;
+
+        @Property public void shouldHold(
+            @InRange(minInt = 1, maxInt = 5) int @Size(min = 4, max = 5) @Distinct [] i) {
+            failed = i;
+
+            fail();
+        }
+    }
+}

--- a/generators/src/test/java/com/pholser/junit/quickcheck/DistinctListPropertyParameterTypesTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/DistinctListPropertyParameterTypesTest.java
@@ -1,0 +1,51 @@
+package com.pholser.junit.quickcheck;
+
+import com.pholser.junit.quickcheck.generator.Distinct;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.internal.Lists;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.*;
+import static org.junit.experimental.results.ResultMatchers.*;
+
+public class DistinctListPropertyParameterTypesTest {
+    @Test public void distinctLists() {
+        assertThat(testResult(DistinctLists.class), isSuccessful());
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class DistinctLists {
+        @Property public void shouldHold(
+            @Size(min = 2, max = 5) @Distinct List<@InRange(minInt = 1, maxInt = 5) Integer> items) {
+            assertThat(items.size(), allOf(greaterThanOrEqualTo(2), lessThanOrEqualTo(5)));
+            assertThat(Lists.isDistinct(items), is(true));
+        }
+    }
+
+    @Test public void shrinkingDistinctLists() {
+        assertThat(testResult(ShrinkingDistinctLists.class), failureCountIs(1));
+        assertThat(
+            ShrinkingDistinctLists.failed.size(),
+            allOf(greaterThanOrEqualTo(4), lessThanOrEqualTo(5)));
+        assertThat(Lists.isDistinct(ShrinkingDistinctLists.failed), is(true));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class ShrinkingDistinctLists {
+        static List<Integer> failed;
+
+        @Property public void shouldHold(
+            @Size(min = 4, max = 5) @Distinct List<@InRange(minInt = 1, maxInt = 5) Integer> items) {
+            failed = items;
+
+            fail();
+        }
+    }
+}

--- a/generators/src/test/java/com/pholser/junit/quickcheck/DistinctMapPropertyParameterTypesTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/DistinctMapPropertyParameterTypesTest.java
@@ -1,0 +1,48 @@
+package com.pholser.junit.quickcheck;
+
+import com.pholser.junit.quickcheck.generator.Distinct;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.*;
+import static org.junit.experimental.results.ResultMatchers.*;
+
+public class DistinctMapPropertyParameterTypesTest {
+    @Test public void distinctMaps() {
+        assertThat(testResult(DistinctMaps.class), isSuccessful());
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class DistinctMaps {
+        @Property public void shouldHold(
+            @Size(min = 4, max = 5) @Distinct Map<@InRange(minInt = 1, maxInt = 5) Integer, Double> items) {
+            assertThat(items.size(), allOf(greaterThanOrEqualTo(4), lessThanOrEqualTo(5)));
+        }
+    }
+
+    @Test public void shrinkingDistinctMaps() {
+        assertThat(testResult(ShrinkingDistinctMaps.class), failureCountIs(1));
+        assertThat(
+            ShrinkingDistinctMaps.failed.size(),
+            allOf(greaterThanOrEqualTo(4), lessThanOrEqualTo(5)));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class ShrinkingDistinctMaps {
+        static Map<Integer, Double> failed;
+
+        @Property public void shouldHold(
+            @Size(min = 4, max = 5) @Distinct Map<@InRange(minInt = 1, maxInt = 5) Integer, Double> items) {
+            failed = items;
+
+            fail();
+        }
+    }
+}

--- a/generators/src/test/java/com/pholser/junit/quickcheck/DistinctSetPropertyParameterTypesTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/DistinctSetPropertyParameterTypesTest.java
@@ -1,0 +1,48 @@
+package com.pholser.junit.quickcheck;
+
+import com.pholser.junit.quickcheck.generator.Distinct;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Set;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.experimental.results.PrintableResult.*;
+import static org.junit.experimental.results.ResultMatchers.*;
+
+public class DistinctSetPropertyParameterTypesTest {
+    @Test public void distinctSets() {
+        assertThat(testResult(DistinctSets.class), isSuccessful());
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class DistinctSets {
+        @Property public void shouldHold(
+            @Size(min = 4, max = 5) @Distinct Set<@InRange(minInt = 1, maxInt = 5) Integer> items) {
+            assertThat(items.size(), allOf(greaterThanOrEqualTo(4), lessThanOrEqualTo(5)));
+        }
+    }
+
+    @Test public void shrinkingDistinctSets() {
+        assertThat(testResult(ShrinkingDistinctSets.class), failureCountIs(1));
+        assertThat(
+            ShrinkingDistinctSets.failed.size(),
+            allOf(greaterThanOrEqualTo(4), lessThanOrEqualTo(5)));
+    }
+
+    @RunWith(JUnitQuickcheck.class)
+    public static class ShrinkingDistinctSets {
+        static Set<Integer> failed;
+
+        @Property public void shouldHold(
+            @Size(min = 4, max = 5) @Distinct Set<@InRange(minInt = 1, maxInt = 5) Integer> items) {
+            failed = items;
+
+            fail();
+        }
+    }
+}


### PR DESCRIPTION
This modification enables:
* Generation of array/Collection/Map whose values/elements/keys are distinct from each other
* Strict size constraint on `Set` and `Map` (`@Size` cannot strictly constrain sizes of `Set` and `Map` without distinct value generation)

@pholser, could you take a look?
