### PR TITLE
For #200, publish a set of executable examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ that the properties hold at least for the generated inputs. This gives us
 some reasonable assurance over time that the properties hold true for any
 valid inputs.
 
-## Getting junit-quickcheck
+## Documentation
  
-[Version 0.8](https://pholser.github.io/junit-quickcheck/index.html) is the
-current stable version of junit-quickcheck.
+Here is a link to the documentation for
+[Version 0.8, the current stable version of junit-quickcheck](https://pholser.github.io/junit-quickcheck/index.html).
 
 ## Basic example
 
@@ -45,3 +45,9 @@ current stable version of junit-quickcheck.
         }
     }
 ```
+
+## Other examples
+
+After browsing the [documentation](#documentation), have a look at some
+[examples](examples) in module `junit-quickcheck-examples`. These are built
+with junit-quickcheck.

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.pholser</groupId>
+        <artifactId>junit-quickcheck</artifactId>
+        <version>0.8.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>junit-quickcheck-examples</artifactId>
+    <version>0.8.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>junit-quickcheck-examples</name>
+    <description>Property-based testing, JUnit-style: examples</description>
+    <url>http://github.com/pholser/junit-quickcheck</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-core</artifactId>
+            <version>0.8.1-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-generators</artifactId>
+            <version>0.8.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.mifmif</groupId>
+            <artifactId>generex</artifactId>
+            <version>1.0.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.pholser</groupId>
+            <artifactId>junit-quickcheck-core</artifactId>
+            <version>0.8.1-SNAPSHOT</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>findbugs-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/counter/Counter.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/counter/Counter.java
@@ -1,0 +1,47 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.counter;
+
+public final class Counter {
+    private int count;
+
+    public Counter() {
+    }
+
+    Counter increment() {
+        ++count;
+        return this;
+    }
+
+    Counter decrement() {
+        --count;
+        return this;
+    }
+
+    int count() {
+        return count;
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/crypto/SymmetricCrypto.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/crypto/SymmetricCrypto.java
@@ -1,0 +1,86 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.crypto;
+
+import java.security.GeneralSecurityException;
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Random;
+import javax.crypto.Cipher;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.spec.IvParameterSpec;
+
+import static javax.crypto.Cipher.*;
+
+final class SymmetricCrypto {
+    private static final int KEY_LENGTH = 128;
+
+    private final Cipher aes;
+    private final Random random = new SecureRandom();
+
+    SymmetricCrypto() {
+        try {
+            aes = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    EncryptionResult encrypt(byte[] plaintext, Key key)
+        throws GeneralSecurityException {
+
+        byte[] iv = initializationVector();
+        aes.init(ENCRYPT_MODE, key, new IvParameterSpec(iv));
+
+        byte[] ciphertext = aes.doFinal(plaintext);
+
+        return new EncryptionResult(ciphertext, iv);
+    }
+
+    byte[] decrypt(EncryptionResult enciphered, Key key)
+        throws GeneralSecurityException {
+
+        aes.init(DECRYPT_MODE, key, new IvParameterSpec(enciphered.iv));
+        return aes.doFinal(enciphered.ciphertext);
+    }
+
+    private byte[] initializationVector() {
+        byte[] iv = new byte[KEY_LENGTH / 8];
+        random.nextBytes(iv);
+        return iv;
+    }
+
+    static class EncryptionResult {
+        final byte[] ciphertext;
+        final byte[] iv;
+
+        EncryptionResult(byte[] ciphertext, byte[] iv) {
+            this.ciphertext = ciphertext;
+            this.iv = iv;
+        }
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/dummy/A.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/dummy/A.java
@@ -1,0 +1,47 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.dummy;
+
+import java.util.List;
+
+class A {
+    private final String someString;
+    private final int someInt;
+    private List<B> listOfB;
+
+    A(String someString, int someInt) {
+        this.someString = someString;
+        this.someInt = someInt;
+    }
+
+    void setListOfB(List<B> listOfB) {
+        this.listOfB = listOfB;
+    }
+
+    @Override public String toString() {
+        return String.format("%s, %d, %s", someString, someInt, listOfB);
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/dummy/B.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/dummy/B.java
@@ -1,0 +1,40 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.dummy;
+
+class B {
+    private final String someString;
+    private final int someInt;
+
+    B(String someString, int someInt) {
+        this.someString = someString;
+        this.someInt = someInt;
+    }
+
+    @Override public String toString() {
+        return String.format("%s, %d", someString, someInt);
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/func/Either.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/func/Either.java
@@ -1,0 +1,73 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.func;
+
+import java.util.Optional;
+import java.util.function.Function;
+
+final class Either<L, R> {
+    private final Optional<L> left;
+    private final Optional<R> right;
+
+    private Either(Optional<L> left, Optional<R> right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    static <A, B> Either<A, B> makeLeft(A left) {
+        return new Either<>(Optional.of(left), Optional.empty());
+    }
+
+    static <A, B> Either<A, B> makeRight(B right) {
+        return new Either<>(Optional.empty(), Optional.of(right));
+    }
+
+    <T, U extends T> T map(
+        Function<? super L, U> ifLeft,
+        Function<? super R, U> ifRight) {
+
+        return left.map(ifLeft)
+            .orElseGet(() -> right.map(ifRight).get());
+    }
+
+    @Override public boolean equals(Object o) {
+        if (!(o instanceof Either<?, ?>))
+            return false;
+
+        Either<?, ?> other = (Either<?, ?>) o;
+        return left.equals(other.left) && right.equals(other.right);
+    }
+
+    @Override public int hashCode() {
+        return 17 + 31 * left.hashCode() + 31 * right.hashCode();
+    }
+
+    @Override public String toString() {
+        return map(
+            ell -> "Left[" + ell + ']',
+            r -> "Right[" + r + ']');
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/geom/Point.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/geom/Point.java
@@ -1,0 +1,78 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import static com.pholser.junit.quickcheck.examples.geom.Point.Orientation.*;
+import static java.lang.Math.*;
+
+/**
+ * @see <a href="https://www.geeksforgeeks.org/program-check-three-points-collinear">Article</a>
+ * @see <a href="https://www.geeksforgeeks.org/how-to-check-if-a-given-point-lies-inside-a-polygon">Article</a>
+ */
+public final class Point {
+    enum Orientation {
+        COLLINEAR,
+        CLOCKWISE,
+        COUNTERCLOCKWISE
+    }
+
+    final double x;
+    final double y;
+
+    Point(int x, int y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    Point(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    boolean collinearWith(Point a, Point b) {
+        return COLLINEAR == orientation(a, this, b);
+    }
+
+    boolean between(Point a, Point b) {
+        return collinearWith(a, b)
+            && x <= max(a.x, b.x) && x >= min(a.x, b.x)
+            && y <= max(a.y, b.y) && y >= min(a.y, b.y);
+    }
+
+    static Orientation orientation(Point p, Point q, Point r) {
+        double val =
+            (q.y - p.y) * (r.x - q.x)
+                - (q.x - p.x) * (r.y - q.y);
+
+        if (val == 0)
+            return COLLINEAR;
+        return val > 0 ? CLOCKWISE : COUNTERCLOCKWISE;
+    }
+
+    @Override public String toString() {
+        return String.format("(%f, %f)", x, y);
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/geom/Polygon.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/geom/Polygon.java
@@ -1,0 +1,107 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.pholser.junit.quickcheck.examples.geom.Point.Orientation.*;
+import static com.pholser.junit.quickcheck.examples.geom.Point.*;
+import static java.util.Comparator.*;
+
+/**
+ * @see <a href="https://www.geeksforgeeks.org/how-to-check-if-a-given-point-lies-inside-a-polygon/">Article</a>
+ * @see <a href="https://bit.ly/2xm22oj">Stack Overflow</a>
+ */
+public final class Polygon {
+    final List<Point> points;
+
+    public Polygon(List<Point> points) {
+        if (points.size() < 3) {
+            throw new IllegalArgumentException(
+                "Need at least three points, got " + points.size());
+        }
+
+        this.points = new ArrayList<>(points);
+        this.points.sort(comparingDouble(a -> Math.atan2(a.y, a.x)));
+    }
+
+    boolean convex() {
+        if (points.size() < 4)
+            return true;
+
+        boolean sign = false;
+        int n = points.size();
+
+        for (int i = 0; i < n; i++) {
+            double dx1 =
+                points.get((i + 2) % n).x - points.get((i + 1) % n).x;
+            double dy1 =
+                points.get((i + 2) % n).y - points.get((i + 1) % n).y;
+            double dx2 =
+                points.get(i).x - points.get((i + 1) % n).x;
+            double dy2 =
+                points.get(i).y - points.get((i + 1) % n).y;
+            double zCrossProduct = dx1 * dy2 - dy1 * dx2;
+
+            if (i == 0)
+                sign = zCrossProduct > 0;
+            else if (sign != (zCrossProduct > 0))
+                return false;
+        }
+
+        return true;
+    }
+
+    boolean contains(Point p) {
+        Point extreme = new Point(Integer.MAX_VALUE, p.y);
+        Segment pToExtreme = new Segment(p, extreme);
+
+        // Count intersections of the above line with sides of polygon
+        int count = 0;
+        int i = 0;
+
+        do {
+            int next = (i + 1) % points.size();
+
+            Segment iToNext = new Segment(points.get(i), points.get(next));
+            if (iToNext.intersects(pToExtreme)) {
+                if (orientation(points.get(i), p, points.get(next)) == COLLINEAR)
+                    return p.between(points.get(i), points.get(next));
+
+                ++count;
+            }
+
+            i = next;
+        } while (i != 0);
+
+        return count % 2 != 0;
+    }
+
+    @Override public String toString() {
+        return points.toString();
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/geom/Segment.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/geom/Segment.java
@@ -1,0 +1,71 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import com.pholser.junit.quickcheck.examples.geom.Point.Orientation;
+
+import static com.pholser.junit.quickcheck.examples.geom.Point.*;
+import static com.pholser.junit.quickcheck.examples.geom.Point.Orientation.*;
+
+final class Segment {
+    final Point a;
+    final Point b;
+
+    Segment(Point a, Point b) {
+        this.a = a;
+        this.b = b;
+    }
+
+    boolean intersects(Segment other) {
+        Orientation o1 = orientation(a, b, other.a);
+        Orientation o2 = orientation(a, b, other.b);
+        Orientation o3 = orientation(other.a, other.b, a);
+        Orientation o4 = orientation(other.a, other.b, b);
+
+        // General case
+        if (o1 != o2 && o3 != o4)
+            return true;
+
+        // Special Cases
+        if (o1 == COLLINEAR && other.a.between(a, b))
+            return true;
+
+        if (o2 == COLLINEAR && other.b.between(a, b))
+            return true;
+
+        if (o3 == COLLINEAR && a.between(other.a, other.b))
+            return true;
+
+        if (o4 == COLLINEAR && b.between(other.a, other.b))
+            return true;
+
+        return false;
+    }
+
+    @Override public String toString() {
+        return String.format("[%s %s]", a, b);
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/money/DollarsAndCents.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/money/DollarsAndCents.java
@@ -1,0 +1,42 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.money;
+
+import java.math.BigDecimal;
+
+import static java.math.RoundingMode.*;
+
+final class DollarsAndCents {
+    private final BigDecimal amount;
+
+    DollarsAndCents(BigDecimal amount) {
+        this.amount = amount.setScale(2, HALF_EVEN);
+    }
+
+    BigDecimal toBigDecimal() {
+        return amount;
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/number/NonNegative.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/number/NonNegative.java
@@ -1,0 +1,40 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.number;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.pholser.junit.quickcheck.generator.GeneratorConfiguration;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE})
+@Retention(RUNTIME)
+@GeneratorConfiguration
+public @interface NonNegative {
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Empty.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Empty.java
@@ -1,0 +1,40 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.examples.tree.visitor.TreeStructureVisitor;
+
+public class Empty implements Tree {
+    @Override public Object accept(TreeVisitor visitor) {
+        return visitor.visit(this);
+    }
+
+    @Override public String toString() {
+        TreeStructureVisitor v = new TreeStructureVisitor();
+        accept(v);
+        return v.toString();
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Leaf.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Leaf.java
@@ -1,0 +1,50 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.examples.tree.visitor.TreeStructureVisitor;
+
+public class Leaf implements Tree {
+    private final String value;
+
+    public Leaf(String value) {
+        this.value = value;
+    }
+
+    @Override public Object accept(TreeVisitor visitor) {
+        return visitor.visit(this);
+    }
+
+    public String value() {
+        return value;
+    }
+
+    @Override public String toString() {
+        TreeStructureVisitor v = new TreeStructureVisitor();
+        accept(v);
+        return v.toString();
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Node.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Node.java
@@ -1,0 +1,56 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.examples.tree.visitor.TreeStructureVisitor;
+
+public class Node implements Tree {
+    private final Tree left;
+    private final Tree right;
+
+    public Node(Tree left, Tree right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override public Object accept(TreeVisitor visitor) {
+        return visitor.visit(this);
+    }
+
+    public Tree left() {
+        return left;
+    }
+
+    public Tree right() {
+        return right;
+    }
+
+    @Override public String toString() {
+        TreeStructureVisitor v = new TreeStructureVisitor();
+        accept(v);
+        return v.toString();
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Tree.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Tree.java
@@ -1,0 +1,38 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+public interface Tree extends Visited<TreeVisitor> {
+    String LOWERCASE_CHARS = "abcdefghijklmnopqrstuvwxyz";
+
+    String UPPERCASE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+    String NUMBERS = "0123456789";
+
+    String ALL_MY_CHARS = LOWERCASE_CHARS + UPPERCASE_CHARS + NUMBERS;
+
+    int LABEL_SIZE = 2;
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/TreeVisitor.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/TreeVisitor.java
@@ -1,0 +1,34 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+public interface TreeVisitor {
+    Object visit(Empty empty);
+
+    Object visit(Leaf leaf);
+
+    Object visit(Node node);
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Visited.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/Visited.java
@@ -1,0 +1,30 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+public interface Visited<V> {
+    Object accept(V visitor);
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/visitor/TreeDeepestLeafVisitor.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/visitor/TreeDeepestLeafVisitor.java
@@ -1,0 +1,59 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree.visitor;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+
+import com.pholser.junit.quickcheck.examples.tree.Empty;
+import com.pholser.junit.quickcheck.examples.tree.Leaf;
+import com.pholser.junit.quickcheck.examples.tree.Node;
+import com.pholser.junit.quickcheck.examples.tree.TreeVisitor;
+
+public class TreeDeepestLeafVisitor implements TreeVisitor {
+    @Override public SimpleImmutableEntry<String, Integer> visit(Empty empty) {
+        return new SimpleImmutableEntry<>("", 0);
+    }
+
+    @Override public SimpleImmutableEntry<String, Integer> visit(Leaf leaf) {
+        return new SimpleImmutableEntry<>(leaf.value(), 0);
+    }
+
+    @Override public SimpleImmutableEntry<String, Integer> visit(Node node) {
+        @SuppressWarnings("unchecked")
+        SimpleImmutableEntry<String, Integer> leftResult =
+            (SimpleImmutableEntry<String, Integer>) node.left().accept(this);
+
+        @SuppressWarnings("unchecked")
+        SimpleImmutableEntry<String, Integer> rightResult =
+            (SimpleImmutableEntry<String, Integer>) node.right().accept(this);
+
+        int leftDepth = leftResult.getValue();
+        int rightDepth = rightResult.getValue();
+        return leftDepth >= rightDepth
+            ? new SimpleImmutableEntry<>(leftResult.getKey(), 1 + leftDepth)
+            : new SimpleImmutableEntry<>(rightResult.getKey(), 1 + rightDepth);
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/visitor/TreeDepthVisitor.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/visitor/TreeDepthVisitor.java
@@ -1,0 +1,47 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree.visitor;
+
+import com.pholser.junit.quickcheck.examples.tree.Empty;
+import com.pholser.junit.quickcheck.examples.tree.Leaf;
+import com.pholser.junit.quickcheck.examples.tree.Node;
+import com.pholser.junit.quickcheck.examples.tree.TreeVisitor;
+
+public class TreeDepthVisitor implements TreeVisitor {
+    @Override public Integer visit(Empty empty) {
+        return 0;
+    }
+
+    @Override public Integer visit(Leaf leaf) {
+        return 0;
+    }
+
+    @Override public Integer visit(Node node) {
+        Integer leftDepth = (Integer) node.left().accept(this);
+        Integer rightDepth = (Integer) node.right().accept(this);
+        return 1 + Math.max(leftDepth, rightDepth);
+    }
+}

--- a/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/visitor/TreeStructureVisitor.java
+++ b/examples/src/main/java/com/pholser/junit/quickcheck/examples/tree/visitor/TreeStructureVisitor.java
@@ -1,0 +1,83 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree.visitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.pholser.junit.quickcheck.examples.tree.Empty;
+import com.pholser.junit.quickcheck.examples.tree.Leaf;
+import com.pholser.junit.quickcheck.examples.tree.Node;
+import com.pholser.junit.quickcheck.examples.tree.TreeVisitor;
+
+import static java.lang.System.*;
+import static java.util.Collections.*;
+import static java.util.stream.Collectors.*;
+
+public class TreeStructureVisitor implements TreeVisitor {
+    private final List<String> lines = new ArrayList<>();
+
+    private int depth;
+
+    @Override public Void visit(Empty empty) {
+        addLine("Empty");
+
+        --depth;
+        return null;
+    }
+
+    @Override public Void visit(Leaf leaf) {
+        addLine("Leaf");
+
+        --depth;
+        return null;
+    }
+
+    @Override public Void visit(Node node) {
+        addLine("Node");
+
+        ++depth;
+        node.left().accept(this);
+
+        ++depth;
+        node.right().accept(this);
+
+        --depth;
+        return null;
+    }
+
+    @Override public String toString() {
+        return lines.stream().collect(joining(getProperty("line.separator")));
+    }
+
+    private void addLine(String label) {
+        lines.add(repeat(" ", depth * 2) + label + ':' + depth);
+    }
+
+    private static String repeat(String s, int times) {
+        return nCopies(times, s).stream().collect(joining());
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/counter/CounterPropertiesTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/counter/CounterPropertiesTest.java
@@ -1,0 +1,48 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.counter;
+
+import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.examples.counter.Counter;
+import com.pholser.junit.quickcheck.generator.Fields;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class CounterPropertiesTest {
+    @Property public void incrementing(@From(Fields.class) Counter c) {
+        int count = c.count();
+        assertEquals(count + 1, c.increment().count());
+    }
+
+    @Property public void decrementing(@From(Fields.class) Counter c) {
+        int count = c.count();
+        assertEquals(count - 1, c.decrement().count());
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/crypto/AES128Keys.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/crypto/AES128Keys.java
@@ -1,0 +1,55 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.crypto;
+
+import java.security.Key;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.KeyGenerator;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class AES128Keys extends Generator<Key> {
+    public AES128Keys() {
+        super(Key.class);
+    }
+
+    @Override public Key generate(
+        SourceOfRandomness random, GenerationStatus status) {
+
+        KeyGenerator keygen;
+        try {
+            keygen = KeyGenerator.getInstance("AES");
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError(e);
+        }
+
+        keygen.init(128);
+
+        return keygen.generateKey();
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/dummy/AGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/dummy/AGenerator.java
@@ -1,0 +1,50 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.dummy;
+
+import java.util.List;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class AGenerator extends Generator<A> {
+    public AGenerator() {
+        super(A.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override public A generate(SourceOfRandomness r, GenerationStatus s) {
+        String someString = gen().type(String.class).generate(r, s);
+        int someInt = gen().type(int.class).generate(r, s);
+        Generator<List> listOfB = gen().type(List.class, B.class);
+
+        A a = new A(someString, someInt);
+        a.setListOfB(listOfB.generate(r, s));
+
+        return a;
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/dummy/BGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/dummy/BGenerator.java
@@ -1,0 +1,43 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.dummy;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class BGenerator extends Generator<B> {
+    public BGenerator() {
+        super(B.class);
+    }
+
+    @Override public B generate(SourceOfRandomness r, GenerationStatus s) {
+        String someString = gen().type(String.class).generate(r, s);
+        int someInt = gen().type(int.class).generate(r, s);
+
+        return new B(someString, someInt);
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/func/EitherGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/func/EitherGenerator.java
@@ -1,0 +1,72 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.func;
+
+import java.util.List;
+
+import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static com.pholser.junit.quickcheck.examples.func.Either.*;
+import static java.util.stream.Collectors.*;
+
+public class EitherGenerator extends ComponentizedGenerator<Either> {
+    public EitherGenerator() {
+        super(Either.class);
+    }
+
+    @Override public Either<?, ?> generate(
+        SourceOfRandomness random,
+        GenerationStatus status) {
+
+        return random.nextBoolean()
+            ? makeLeft(componentGenerators().get(0).generate(random, status))
+            : makeRight(componentGenerators().get(1).generate(random, status));
+    }
+
+    @Override public List<Either> doShrink(
+        SourceOfRandomness random,
+        Either larger) {
+
+        @SuppressWarnings("unchecked")
+        Either<Object, Object> either = (Either<Object, Object>) larger;
+
+        return either.map(
+            left -> componentGenerators().get(0).shrink(random, left)
+                .stream()
+                .map(Either::makeLeft)
+                .collect(toList()),
+            right -> componentGenerators().get(1).shrink(random, right)
+                .stream()
+                .map(Either::makeRight)
+                .collect(toList()));
+    }
+
+    @Override public int numberOfNeededComponents() {
+        return 2;
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/func/EitherTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/func/EitherTest.java
@@ -1,0 +1,34 @@
+package com.pholser.junit.quickcheck.examples.func;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class EitherTest {
+    @Property
+    public void withRanges(
+        Either<
+            @InRange(minInt = 0) Integer,
+            @InRange(minDouble = -7.0, maxDouble = -4.0) Double> e) {
+
+        e.map(
+            left -> {
+                assertThat(left, greaterThanOrEqualTo(0));
+                return 0;
+            },
+            right -> {
+                assertThat(
+                    right,
+                    allOf(
+                        greaterThanOrEqualTo(-7.0),
+                        lessThanOrEqualTo(-4.0)));
+                return 1;
+            }
+        );
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/Dimensions.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/Dimensions.java
@@ -1,0 +1,47 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import java.awt.Dimension;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static java.lang.Math.*;
+
+public class Dimensions extends Generator<Dimension> {
+    public Dimensions() {
+        super(Dimension.class);
+    }
+
+    @Override public Dimension generate(
+        SourceOfRandomness r,
+        GenerationStatus status) {
+
+        return new Dimension(abs(r.nextInt()), abs(r.nextInt()));
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/PointGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/PointGenerator.java
@@ -1,0 +1,55 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import java.util.List;
+
+import com.pholser.junit.quickcheck.examples.geom.Point;
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static java.util.Collections.*;
+
+public class PointGenerator extends Generator<Point> {
+    public PointGenerator() {
+        super(Point.class);
+    }
+
+    @Override public Point generate(
+        SourceOfRandomness r,
+        GenerationStatus s) {
+
+        return new Point(r.nextInt(), r.nextInt());
+    }
+
+    @Override public List<Point> doShrink(
+        SourceOfRandomness r,
+        Point larger) {
+
+        return singletonList(new Point(larger.x / 2, larger.y / 2));
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/PolygonGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/PolygonGenerator.java
@@ -1,0 +1,71 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import java.util.List;
+
+import com.pholser.junit.quickcheck.examples.geom.Point;
+import com.pholser.junit.quickcheck.examples.geom.Polygon;
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Size;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static java.util.Collections.*;
+import static java.util.stream.Collectors.*;
+
+public class PolygonGenerator extends Generator<Polygon> {
+    private static final @Size(min = 3, max = 30) List<Point> POINTS = null;
+
+    public PolygonGenerator() {
+        super(Polygon.class);
+    }
+
+    @Override public Polygon generate(
+        SourceOfRandomness r,
+        GenerationStatus s) {
+
+        Generator<List<Point>> points =
+            (Generator<List<Point>>) gen().field(
+                getClass(),
+                "POINTS");
+
+        return new Polygon(points.generate(r, s));
+    }
+
+    @Override public List<Polygon> doShrink(
+        SourceOfRandomness r,
+        Polygon larger) {
+
+        Generator<Point> pointGen = gen().type(Point.class);
+
+        return singletonList(
+            new Polygon(
+                larger.points.stream()
+                    .map(p -> pointGen.shrink(r, p).get(0))
+                    .collect(toList())));
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/PolygonPropertiesTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/PolygonPropertiesTest.java
@@ -1,0 +1,57 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.examples.geom.Point;
+import com.pholser.junit.quickcheck.examples.geom.Polygon;
+import com.pholser.junit.quickcheck.generator.InRange;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class PolygonPropertiesTest {
+    @Property(trials = 150) public void convexity(
+        Polygon polygon,
+        Point p,
+        Point q,
+        @InRange(minDouble = 0, maxDouble = 1) double alpha) {
+
+        assumeTrue(polygon.convex());
+        assumeTrue(polygon.contains(p));
+        assumeTrue(polygon.contains(q));
+
+        Point r =
+            new Point(
+                alpha * p.x + (1 - alpha) * q.x,
+                alpha * p.y + (1 - alpha) * q.y);
+
+        assertTrue(polygon.contains(r));
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/SegmentGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/SegmentGenerator.java
@@ -1,0 +1,66 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import java.util.List;
+
+import com.pholser.junit.quickcheck.examples.geom.Point;
+import com.pholser.junit.quickcheck.examples.geom.Segment;
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static com.google.common.collect.Streams.*;
+import static java.util.stream.Collectors.*;
+
+public class SegmentGenerator extends Generator<Segment> {
+    public SegmentGenerator() {
+        super(Segment.class);
+    }
+
+    @Override public Segment generate(
+        SourceOfRandomness r,
+        GenerationStatus s) {
+
+        Generator<Point> pointGen = gen().type(Point.class);
+        return new Segment(
+            pointGen.generate(r, s),
+            pointGen.generate(r, s));
+    }
+
+    @Override public List<Segment> doShrink(
+        SourceOfRandomness r,
+        Segment larger) {
+
+        Generator<Point> pointGen = gen().type(Point.class);
+
+        return zip(
+            pointGen.shrink(r, larger.a).stream(),
+            pointGen.shrink(r, larger.b).stream(),
+            Segment::new
+        ).collect(toList());
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/SegmentPropertiesTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/geom/SegmentPropertiesTest.java
@@ -1,0 +1,43 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.geom;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.examples.geom.Segment;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class SegmentPropertiesTest {
+    @Property public void intersectionIsSymmetric(
+        Segment a,
+        Segment b) {
+
+        assertEquals(a.intersects(b), b.intersects(a));
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/money/DollarsAndCentsPropertiesTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/money/DollarsAndCentsPropertiesTest.java
@@ -1,0 +1,70 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.money;
+
+import java.math.BigDecimal;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.generator.Precision;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static java.math.BigDecimal.*;
+import static java.math.RoundingMode.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+import static org.junit.Assume.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class DollarsAndCentsPropertiesTest {
+    @Property public void roundingDown(@Precision(scale = 8) BigDecimal d) {
+        BigDecimal[] pieces = d.divideAndRemainder(ONE);
+        BigDecimal integral = pieces[0];
+        BigDecimal fractional = pieces[1];
+
+        assumeThat(fractional, lessThanOrEqualTo(new BigDecimal("0.5")));
+
+        DollarsAndCents money = new DollarsAndCents(d);
+
+        assertEquals(
+            integral.add(fractional).setScale(2, HALF_DOWN),
+            money.toBigDecimal());
+    }
+
+    @Property public void roundingUp(@Precision(scale = 8) BigDecimal d) {
+        BigDecimal[] pieces = d.divideAndRemainder(ONE);
+        BigDecimal integral = pieces[0];
+        BigDecimal fractional = pieces[1];
+
+        assumeThat(fractional, greaterThan(new BigDecimal("0.5")));
+
+        DollarsAndCents money = new DollarsAndCents(d);
+
+        assertEquals(
+            integral.add(fractional).setScale(2, HALF_UP),
+            money.toBigDecimal());
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/number/IntegralGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/number/IntegralGenerator.java
@@ -1,0 +1,53 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.number;
+
+import java.util.Arrays;
+
+import com.pholser.junit.quickcheck.examples.number.NonNegative;
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class IntegralGenerator extends Generator<Integer> {
+    private NonNegative nonNegative;
+
+    public IntegralGenerator() {
+        super(Arrays.asList(Integer.class, int.class));
+    }
+
+    @Override public Integer generate(
+        SourceOfRandomness random,
+        GenerationStatus status) {
+
+        int value = random.nextInt();
+        return nonNegative != null ? Math.abs(value) : value;
+    }
+
+    public void configure(NonNegative nonNegative) {
+        this.nonNegative = nonNegative;
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/number/NumbersPropertiesTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/number/NumbersPropertiesTest.java
@@ -1,0 +1,41 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.number;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.examples.number.NonNegative;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class NumbersPropertiesTest {
+    @Property public void nonNegativity(@NonNegative int i) {
+        assertThat(i, greaterThanOrEqualTo(0));
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/text/SSNTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/text/SSNTest.java
@@ -1,0 +1,50 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.text;
+
+import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.examples.text.Structured.Matching;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class SSNTest {
+    @Property
+    public void wellFormedSSN(
+        @From(Structured.class)
+        @Matching("\\d{3}-\\d{2}-\\d{4}") String ssn) {
+
+        String[] pieces = ssn.split("-");
+        assertEquals(3, pieces.length);
+        for (String each : pieces) {
+            for (int i = 0; i < each.length(); ++i)
+                assertTrue(Character.isDigit(each.charAt(i)));
+        }
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/text/StringPropertiesTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/text/StringPropertiesTest.java
@@ -1,0 +1,39 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.text;
+
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class StringPropertiesTest {
+    @Property public void concatenationLength(String s1, String s2) {
+        assertEquals(s1.length() + s2.length(), (s1 + s2).length());
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/text/Structured.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/text/Structured.java
@@ -1,0 +1,67 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.text;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.mifmif.common.regex.Generex;
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.GeneratorConfiguration;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+public class Structured extends Generator<String> {
+    private Matching matching;
+
+    public Structured() {
+        super(String.class);
+    }
+
+    @Override public String generate(
+        SourceOfRandomness r,
+        GenerationStatus s) {
+
+        Generex regex = new Generex(
+            matching != null ? matching.value() : ".*",
+            r.toJDKRandom());
+        return regex.random(0, s.size());
+    }
+
+    public void configure(Matching matching) {
+        this.matching = matching;
+    }
+
+    @Target({ PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE })
+    @Retention(RUNTIME)
+    @GeneratorConfiguration
+    public @interface Matching {
+        String value();
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/Depth.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/Depth.java
@@ -1,0 +1,43 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import com.pholser.junit.quickcheck.generator.GeneratorConfiguration;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+@Target({ PARAMETER, FIELD, ANNOTATION_TYPE, TYPE_USE })
+@Retention(RUNTIME)
+@GeneratorConfiguration
+public @interface Depth {
+    int min() default 0;
+
+    int max();
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/EmptyGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/EmptyGenerator.java
@@ -1,0 +1,44 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class EmptyGenerator extends Generator<Empty> {
+    public EmptyGenerator() {
+        super(Empty.class);
+    }
+
+    @Override public Empty generate(SourceOfRandomness r, GenerationStatus s) {
+        return new Empty();
+    }
+
+    @Override public boolean canRegisterAsType(Class<?> type) {
+        return Tree.class.isAssignableFrom(type);
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/LeafGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/LeafGenerator.java
@@ -1,0 +1,44 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class LeafGenerator extends Generator<Leaf> {
+    public LeafGenerator() {
+        super(Leaf.class);
+    }
+
+    @Override public Leaf generate(SourceOfRandomness r, GenerationStatus s) {
+        return new Leaf(gen().type(String.class).generate(r, s));
+    }
+
+    @Override public boolean canRegisterAsType(Class<?> type) {
+        return Tree.class.isAssignableFrom(type);
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/NodeGenerator.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/NodeGenerator.java
@@ -1,0 +1,60 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+public class NodeGenerator extends Generator<Node> {
+    public NodeGenerator() {
+        super(Node.class);
+    }
+
+    @Override public Node generate(SourceOfRandomness r, GenerationStatus s) {
+        int depth = s.valueOf(TreeKeys.DEPTH).orElse(1);
+
+        if (depth == 1) {
+            Generator<Tree> leafOrEmpty = gen().oneOf(Leaf.class, Empty.class);
+            return new Node(
+                leafOrEmpty.generate(r, s),
+                leafOrEmpty.generate(r, s)
+            );
+        }
+
+        Generator<Tree> subtree =
+            gen().oneOf(Node.class, Leaf.class, Empty.class);
+        s.setValue(TreeKeys.DEPTH, depth - 1);
+        return new Node(
+            subtree.generate(r, s),
+            subtree.generate(r, s)
+        );
+    }
+
+    @Override public boolean canRegisterAsType(Class<?> type) {
+        return Tree.class.isAssignableFrom(type);
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/TreeKeys.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/TreeKeys.java
@@ -1,0 +1,12 @@
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+
+final class TreeKeys {
+    static final GenerationStatus.Key<Integer> DEPTH =
+        new GenerationStatus.Key<>("depth", Integer.class);
+
+    private TreeKeys() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/TreeMaker.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/TreeMaker.java
@@ -1,0 +1,68 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.internal.Ranges;
+import com.pholser.junit.quickcheck.random.SourceOfRandomness;
+
+import static com.pholser.junit.quickcheck.internal.Ranges.*;
+
+public class TreeMaker extends Generator<Tree> {
+    private Depth range;
+
+    public TreeMaker() {
+        super(Tree.class);
+    }
+
+    public void configure(Depth range) {
+        if (range != null)
+            checkRange(Ranges.Type.INTEGRAL, range.min(), range.max());
+
+        this.range = range;
+    }
+
+    @Override public Tree generate(SourceOfRandomness r, GenerationStatus s) {
+        int depth = this.range == null
+            ? s.size() / 2
+            : r.nextInt(this.range.min(), this.range.max());
+
+        switch (depth) {
+            case 0:
+                return gen().type(Empty.class).generate(r, s);
+            case 1:
+                return gen().type(Leaf.class).generate(r, s);
+            default:
+                s.setValue(TreeKeys.DEPTH, depth);
+                return gen().type(Node.class).generate(r, s);
+        }
+    }
+
+    @Override public boolean canRegisterAsType(Class<?> type) {
+        return false;
+    }
+}

--- a/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/TreePropertyTest.java
+++ b/examples/src/test/java/com/pholser/junit/quickcheck/examples/tree/TreePropertyTest.java
@@ -1,0 +1,67 @@
+/*
+ The MIT License
+
+ Copyright (c) 2010-2018 Paul R. Holser, Jr.
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the
+ "Software"), to deal in the Software without restriction, including
+ without limitation the rights to use, copy, modify, merge, publish,
+ distribute, sublicense, and/or sell copies of the Software, and to
+ permit persons to whom the Software is furnished to do so, subject to
+ the following conditions:
+
+ The above copyright notice and this permission notice shall be
+ included in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+package com.pholser.junit.quickcheck.examples.tree;
+
+import java.util.AbstractMap.SimpleImmutableEntry;
+
+import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.Property;
+import com.pholser.junit.quickcheck.examples.tree.visitor.TreeDeepestLeafVisitor;
+import com.pholser.junit.quickcheck.examples.tree.visitor.TreeDepthVisitor;
+import com.pholser.junit.quickcheck.runner.JUnitQuickcheck;
+import org.junit.runner.RunWith;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+@RunWith(JUnitQuickcheck.class)
+public class TreePropertyTest {
+    @Property public void deepestLeafConstrained(
+        @From(TreeMaker.class)
+        @Depth(min = 10, max = 10)
+        Tree t) {
+
+        TreeDeepestLeafVisitor visitor = new TreeDeepestLeafVisitor();
+
+        @SuppressWarnings("unchecked")
+        SimpleImmutableEntry<String, Integer> result =
+            (SimpleImmutableEntry<String, Integer>) t.accept(visitor);
+
+        assertThat(result.getValue(), lessThanOrEqualTo(10));
+    }
+
+    @Property public void depthConstrained(
+        @From(TreeMaker.class)
+        @Depth(min = 10, max = 10)
+        Tree t) {
+
+        TreeDepthVisitor visitor = new TreeDepthVisitor();
+
+        int result = (int) t.accept(visitor);
+
+        assertThat(result, lessThanOrEqualTo(10));
+    }
+}

--- a/examples/src/test/resources/META-INF/services/com.pholser.junit.quickcheck.generator.Generator
+++ b/examples/src/test/resources/META-INF/services/com.pholser.junit.quickcheck.generator.Generator
@@ -1,0 +1,11 @@
+com.pholser.junit.quickcheck.examples.crypto.AES128Keys
+com.pholser.junit.quickcheck.examples.dummy.AGenerator
+com.pholser.junit.quickcheck.examples.dummy.BGenerator
+com.pholser.junit.quickcheck.examples.func.EitherGenerator
+com.pholser.junit.quickcheck.examples.geom.PointGenerator
+com.pholser.junit.quickcheck.examples.geom.PolygonGenerator
+com.pholser.junit.quickcheck.examples.geom.SegmentGenerator
+com.pholser.junit.quickcheck.examples.number.IntegralGenerator
+com.pholser.junit.quickcheck.examples.tree.EmptyGenerator
+com.pholser.junit.quickcheck.examples.tree.LeafGenerator
+com.pholser.junit.quickcheck.examples.tree.NodeGenerator

--- a/generators/src/test/java/com/pholser/junit/quickcheck/generator/java/util/OptionalPropertyParameterTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/generator/java/util/OptionalPropertyParameterTest.java
@@ -59,7 +59,9 @@ public class OptionalPropertyParameterTest {
 
     @Test public void shrinking() {
         assertThat(testResult(ShrinkingOptional.class), failureCountIs(1));
-        assertTrue(ShrinkingOptional.failed.stream().anyMatch(o -> !o.isPresent()));
+        assertTrue(
+            ShrinkingOptional.failed.stream()
+                .anyMatch(o -> !o.isPresent()));
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <module>core</module>
         <module>generators</module>
         <module>guava</module>
+        <module>examples</module>
     </modules>
 
     <dependencyManagement>

--- a/src/site/markdown/usage/other-types.md
+++ b/src/site/markdown/usage/other-types.md
@@ -95,7 +95,7 @@ by using the `Ctor` generator with `@From`.
     public class DollarsAndCents {
         private final BigDecimal amount;
 
-        public Money(BigDecimal amount) {
+        public DollarsAndCents(BigDecimal amount) {
            this.amount = amount.setScale(2, BigDecimal.ROUND_HALF_EVEN);
         }
 


### PR DESCRIPTION
Most of these examples were taken from the `junit-quickcheck-scratchpad`
project.

Also added clearer links to the generated docs from the README, as well as
links to the executable examples.