### PR TITLE
For #205, change Generator.magnitude() to default to 1

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Generator.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Generator.java
@@ -149,7 +149,7 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * <p>Gives a hint to the shrinking process as to the magnitude of the given
      * value. The shrinking process will prefer trying values of greater
      * magnitude before values of lesser magnitude. If not overridden, this
-     * implementation returns zero.</p>
+     * implementation returns "one".</p>
      *
      * <p><em>Note to generator writers:</em> Do not worry about normalizing
      * a magnitude to a positive value; the shrinking mechanism will take care
@@ -160,7 +160,7 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * @return a measure of the given value's magnitude
      */
     public BigDecimal magnitude(Object value) {
-        return ZERO;
+        return ONE;
     }
 
     /**


### PR DESCRIPTION
The shrinking mechanism discards candidate shrink values that have
equal or lesser "magnitude" than the smallest counterexample found
so far. Generators tell the magnitude of the values they produce.
Collections and other aggregate types have a magnitude that is
a function of the magnitude of their elements.

Prior to this change, if a generator writer did not override
`magnitude()`, then any given output from the generator would have
magnitude zero. This proves problematic when generating collections
of such values, because any list-of-X would have a magnitude of zero,
and no shrinking would occur.

The fix implemented in this change is to change this default
magnitude to one.

Follow-on changes that might be helpful: document some more of the
innards of the shrinking mechanism and how a generator writer can
influence it; and be able to override a generator's shrink()
strategy via annotation on property parameter as a one-shot deal,
rather than leaning on an implementation of `Generator.magnitude()`.