### PR TITLE
Add nullability annotations to main API and extension points

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -42,6 +42,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.hamcrest</groupId>

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/ComponentizedGenerator.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/ComponentizedGenerator.java
@@ -31,6 +31,8 @@ import java.util.List;
 
 import org.javaruntype.type.TypeParameter;
 
+import javax.annotation.Nonnull;
+
 import static java.util.Collections.*;
 
 import static com.pholser.junit.quickcheck.internal.Reflection.*;
@@ -105,6 +107,7 @@ public abstract class ComponentizedGenerator<T> extends Generator<T> {
     /**
      * @return this generator's component generators
      */
+    @Nonnull
     protected List<Generator<?>> componentGenerators() {
         return unmodifiableList(components);
     }

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Gen.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Gen.java
@@ -37,6 +37,8 @@ import com.pholser.junit.quickcheck.internal.Items;
 import com.pholser.junit.quickcheck.internal.Weighted;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
+import javax.annotation.Nonnull;
+
 import static java.util.stream.Collectors.*;
 
 /**
@@ -57,7 +59,7 @@ public interface Gen<T> {
      * number of elements.
      * @return the generated value
      */
-    T generate(SourceOfRandomness random, GenerationStatus status);
+    T generate(@Nonnull SourceOfRandomness random, @Nonnull GenerationStatus status);
 
     /**
      * Gives a generation strategy that produces a random value by having this

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/GenerationStatus.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/GenerationStatus.java
@@ -25,6 +25,8 @@
 
 package com.pholser.junit.quickcheck.generator;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -65,6 +67,7 @@ public interface GenerationStatus {
      * @param value the associated value
      * @return self, so that calls to this method can be chained
      */
+    @Nonnull
     <T> GenerationStatus setValue(Key<T> key, T value);
 
     /**
@@ -74,6 +77,7 @@ public interface GenerationStatus {
      * @param key key to look up
      * @return the (optional) associated value
      */
+    @Nonnull
     <T> Optional<T> valueOf(Key<T> key);
 
     /**
@@ -96,6 +100,7 @@ public interface GenerationStatus {
             this.type = type;
         }
 
+        @Nullable
         public T cast(Object o) {
             return type.cast(o);
         }

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Generator.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Generator.java
@@ -42,6 +42,8 @@ import org.javaruntype.type.TypeParameter;
 import org.javaruntype.type.Types;
 import org.javaruntype.type.WildcardTypeParameter;
 
+import javax.annotation.Nonnull;
+
 import static java.math.BigDecimal.*;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
@@ -82,6 +84,7 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * @return class tokens for the types of property parameters this generator
      * is applicable to
      */
+    @Nonnull
     public List<Class<T>> types() {
         return unmodifiableList(types);
     }
@@ -105,7 +108,8 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * participate} in shrinking the given value, and if so, they
      * {@linkplain #doShrink(SourceOfRandomness, Object) produce shrinks}.</p>
      */
-    @Override public final List<T> shrink(SourceOfRandomness random, Object larger) {
+    @Nonnull
+    @Override public final List<T> shrink(@Nonnull SourceOfRandomness random, Object larger) {
         if (!canShrink(larger)) {
             throw new IllegalStateException(
                 getClass() + " not capable of shrinking " + larger);
@@ -141,7 +145,8 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * @param larger the larger object
      * @return objects that are "smaller" than the larger object
      */
-    public List<T> doShrink(SourceOfRandomness random, T larger) {
+    @Nonnull
+    public List<T> doShrink(@Nonnull SourceOfRandomness random, T larger) {
         return emptyList();
     }
 
@@ -159,6 +164,7 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * @param value the value to assess
      * @return a measure of the given value's magnitude
      */
+    @Nonnull
     public BigDecimal magnitude(Object value) {
         return ONE;
     }
@@ -214,7 +220,7 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      *
      * @param newComponents component generators to add
      */
-    public void addComponentGenerators(List<Generator<?>> newComponents) {
+    public void addComponentGenerators(@Nonnull List<Generator<?>> newComponents) {
         // do nothing by default
     }
 
@@ -224,7 +230,7 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * for property parameters that have the given type parameters in their
      * signatures
      */
-    public boolean canGenerateForParametersOfTypes(List<TypeParameter<?>> typeParameters) {
+    public boolean canGenerateForParametersOfTypes(@Nonnull List<TypeParameter<?>> typeParameters) {
         return true;
     }
 
@@ -254,14 +260,14 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      * "understand" one of the generation configuration annotations on
      * the annotated type
      */
-    public void configure(AnnotatedType annotatedType) {
+    public void configure(@Nonnull AnnotatedType annotatedType) {
         configureStrict(collectConfigurationAnnotations(annotatedType));
     }
 
     /**
      * @param element an annotated program element
      */
-    public void configure(AnnotatedElement element) {
+    public void configure(@Nonnull AnnotatedElement element) {
         configureLenient(collectConfigurationAnnotations(element));
     }
 
@@ -282,6 +288,7 @@ public abstract class Generator<T> implements Gen<T>, Shrink<T> {
      *
      * @return a copy of the receiver
      */
+    @Nonnull
     @SuppressWarnings("unchecked")
     public Generator<T> copy() {
         return (Generator<T>) instantiate(getClass());

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Generators.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Generators.java
@@ -30,6 +30,8 @@ import java.lang.reflect.Parameter;
 
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
+import javax.annotation.Nonnull;
+
 /**
  * An access point for available generators.
  */
@@ -47,6 +49,7 @@ public interface Generators {
      * @param rest other (related) types of generated values
      * @return generator that can produce values of the given types
      */
+    @Nonnull
     <T> Generator<T> oneOf(
         Class<? extends T> first,
         Class<? extends T>... rest);
@@ -63,6 +66,7 @@ public interface Generators {
      * @param rest other generators
      * @return generator that can produce values using the given generators
      */
+    @Nonnull
     <T> Generator<T> oneOf(
         Generator<? extends T> first,
         Generator<? extends T>... rest);
@@ -79,6 +83,7 @@ public interface Generators {
      * @param fieldName name of a field
      * @return generator that can produce values of the field's type
      */
+    @Nonnull
     Generator<?> field(Class<?> type, String fieldName);
 
     /**
@@ -97,6 +102,7 @@ public interface Generators {
      * @param argumentTypes types of arguments to the constructor
      * @return generator that can produce values using the constructor
      */
+    @Nonnull
     <T> Generator<T> constructor(Class<T> type, Class<?>... argumentTypes);
 
     /**
@@ -114,6 +120,7 @@ public interface Generators {
      * @param type a type
      * @return generator that can produce values of that type
      */
+    @Nonnull
     <T> Generator<T> fieldsOf(Class<T> type);
 
     /**
@@ -126,6 +133,7 @@ public interface Generators {
      * @return generator that can produce values of that type
      * @see ComponentizedGenerator
      */
+    @Nonnull
     <T> Generator<T> type(Class<T> type, Class<?>... componentTypes);
 
     /**
@@ -139,6 +147,7 @@ public interface Generators {
      * @param parameter a reflected method parameter
      * @return generator that can produce values of the parameter's type
      */
+    @Nonnull
     Generator<?> parameter(Parameter parameter);
 
     /**
@@ -152,6 +161,7 @@ public interface Generators {
      * @param field a reflected field
      * @return generator that can produce values of the field's type
      */
+    @Nonnull
     Generator<?> field(Field field);
 
     /**
@@ -168,6 +178,7 @@ public interface Generators {
      * @return a generator for producing values
      * @see ComponentizedGenerator
      */
+    @Nonnull
     <T extends Generator<?>> T make(
         Class<T> genType,
         Generator<?>... componentGenerators);
@@ -182,5 +193,6 @@ public interface Generators {
      * @return a generator access point that has the source of randomness
      * available to it
      */
+    @Nonnull
     Generators withRandom(SourceOfRandomness random);
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Shrink.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Shrink.java
@@ -29,6 +29,8 @@ import java.util.List;
 
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
+import javax.annotation.Nonnull;
+
 /**
  * Represents a strategy for producing objects "smaller than" a given object.
  *
@@ -43,5 +45,6 @@ public interface Shrink<T> {
      * @param larger the larger object
      * @return objects that are "smaller" than the larger object
      */
-    List<T> shrink(SourceOfRandomness random, Object larger);
+    @Nonnull
+    List<T> shrink(@Nonnull SourceOfRandomness random, Object larger);
 }

--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/GeneratorRepository.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/generator/GeneratorRepository.java
@@ -54,6 +54,8 @@ import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 import org.javaruntype.type.TypeParameter;
 import org.javaruntype.type.Types;
 
+import javax.annotation.Nonnull;
+
 import static java.util.Arrays.*;
 import static java.util.Collections.*;
 import static java.util.stream.Collectors.*;
@@ -126,10 +128,12 @@ public class GeneratorRepository implements Generators {
         forType.add(generator);
     }
 
+    @Nonnull
     @Override public Generator<?> field(Class<?> type, String fieldName) {
         return field(findField(type, fieldName));
     }
 
+    @Nonnull
     @Override public <U> Generator<U> constructor(
         Class<U> type,
         Class<?>... argumentTypes) {
@@ -142,6 +146,7 @@ public class GeneratorRepository implements Generators {
         return ctor;
     }
 
+    @Nonnull
     @Override public <U> Generator<U> fieldsOf(Class<U> type) {
         Fields<U> fields = new Fields<>(type);
 
@@ -151,6 +156,7 @@ public class GeneratorRepository implements Generators {
         return fields;
     }
 
+    @Nonnull
     @SuppressWarnings("unchecked")
     @Override public <T> Generator<T> type(Class<T> type, Class<?>... componentTypes) {
         Generator<T> generator =
@@ -160,6 +166,7 @@ public class GeneratorRepository implements Generators {
         return generator;
     }
 
+    @Nonnull
     @Override public Generator<?> parameter(Parameter parameter) {
         return produceGenerator(
             new ParameterTypeContext(
@@ -169,6 +176,7 @@ public class GeneratorRepository implements Generators {
             ).annotate(parameter));
     }
 
+    @Nonnull
     @Override public Generator<?> field(Field field) {
         return produceGenerator(
             new ParameterTypeContext(
@@ -178,6 +186,7 @@ public class GeneratorRepository implements Generators {
             ).annotate(field));
     }
 
+    @Nonnull
     @SafeVarargs
     @SuppressWarnings("unchecked")
     @Override public final <T> Generator<T> oneOf(
@@ -191,6 +200,7 @@ public class GeneratorRepository implements Generators {
                 .toArray(Generator[]::new));
     }
 
+    @Nonnull
     @SafeVarargs
     @SuppressWarnings("unchecked")
     @Override public final <T> Generator<T> oneOf(
@@ -208,6 +218,7 @@ public class GeneratorRepository implements Generators {
         return (Generator<T>) new CompositeGenerator(weightings);
     }
 
+    @Nonnull
     @Override public final <T extends Generator<?>> T make(
         Class<T> genType,
         Generator<?>... components) {
@@ -220,6 +231,7 @@ public class GeneratorRepository implements Generators {
         return generator;
     }
 
+    @Nonnull
     @Override public final Generators withRandom(SourceOfRandomness other) {
         return new GeneratorRepository(other, this.generators);
     }

--- a/core/src/main/java/com/pholser/junit/quickcheck/random/SourceOfRandomness.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/random/SourceOfRandomness.java
@@ -38,6 +38,8 @@ import java.util.Random;
 
 import com.pholser.junit.quickcheck.internal.Ranges;
 
+import javax.annotation.Nonnull;
+
 import static java.util.concurrent.TimeUnit.*;
 
 import static com.pholser.junit.quickcheck.internal.Ranges.*;
@@ -297,6 +299,7 @@ public class SourceOfRandomness {
      * @return a random {@code BigInteger}
      * @see BigInteger#BigInteger(int, java.util.Random)
      */
+    @Nonnull
     public BigInteger nextBigInteger(int numberOfBits) {
         return new BigInteger(numberOfBits, delegate);
     }
@@ -309,6 +312,7 @@ public class SourceOfRandomness {
      * @param max upper bound of the desired interval
      * @return a random value
      */
+    @Nonnull
     public Instant nextInstant(Instant min, Instant max) {
         int comparison = checkRange(Ranges.Type.STRING, min, max);
         if (comparison == 0)
@@ -331,6 +335,7 @@ public class SourceOfRandomness {
      * @param max upper bound of the desired interval
      * @return a random value
      */
+    @Nonnull
     public Duration nextDuration(Duration min, Duration max) {
         int comparison = checkRange(Ranges.Type.STRING, min, max);
         if (comparison == 0)

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,11 @@
                 <artifactId>logback-classic</artifactId>
                 <version>1.2.3</version>
             </dependency>
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR adds nullability annotations (JSR 305) to the main API and extension points. For conciseness and safety, the annotations are not comprehensive. There is a lot of room to continue annotating, but in this PR I have selected the methods that are likely to have a bigger impact.

These annotations provide a richer API contract that allows compilers, IDEs and static analysis tools to do a better job at helping developers and preventing bugs.

For example, before this PR, if a developer wanted to implement a new `Gen` in Kotlin, the IDE would automatically generate the following skeleton:

```kotlin
class MyGenerator : Gen<String> {
    override fun generate(sourceOfRandomness: SourceOfRandomness?, generationStatus: GenerationStatus?): String {
        TODO("implementation goes here")
    }
}
```

The question marks after the parameter types indicate that the parameters are nullable, because the IDE does not know better and makes the safest choice on behalf of the developer (this is called a "platform type" in Kotlin). The developer then has two choices:
* keep the question marks and explicitly handle the nullable value, if the developer doesn't know better either and wants to be defensive, or
* remove the question marks to indicate to the compiler that the developer is sure the values are non-nullable. That requires the developer to understand the intention of the library creator.

With the changes in this PR, the two parameters are now annotated with `@Nonnull` in the interface. The IDE will generate the following skeleton:

```kotlin
class MyGenerator : Gen<String> {
    override fun generate(sourceOfRandomness: SourceOfRandomness, generationStatus: GenerationStatus): String {
        TODO("implementation goes here")
    }
}
```

Note the absence of question marks. The developer does not need to be defensive and handle a hypothetical null, and the type checker can guarantee that the implementation of the method is NPE-free.

The drawback of this change is that it may cause compilation errors in some applications. Going back to the first example, if the developer decided to keep the question marks, this PR will cause a compilation error, because the `generate` method in the application no longer overrides the `generate` method in the interface (they have different signatures). The fix is simple: just remove the question marks to match the signature of the interface. This problem may affect some Kotlin users, and potentially also Java applications using static analysis tools like Findbugs.