### PR TITLE
Change documentation link text to be more general

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@ valid inputs.
 
 ## Documentation
  
-Here is a link to the documentation for
-[Version 0.8.1, the current stable version of junit-quickcheck](https://pholser.github.io/junit-quickcheck/index.html).
+[Documentation for the current stable version](https://pholser.github.io/junit-quickcheck/index.html)
 
 ## Basic example
 


### PR DESCRIPTION
Previously it lied and said it was the 0.81 documentation, but it currently is version 0.82 documentation and I think this will change dynamically.