### PR TITLE
Add documentation to warn about edge case

### DIFF
--- a/src/site/markdown/usage/other-types.md
+++ b/src/site/markdown/usage/other-types.md
@@ -21,6 +21,8 @@ junit-quickcheck can instantiate your generator, ensure that it has a
     }
 ```
 
+If you define your generator as an inner class, ensure that it is static, otherwise
+it will fail at runtime.
 
 ## Explicit generators
 


### PR DESCRIPTION
When using non-static inner classes for generators, `com.pholser.junit.quickcheck.internal.ReflectionException: java.lang.InstantiationException` gets thrown.