### PR TITLE
Avoid repeated computations in #generate() methods

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/generator/Fields.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/generator/Fields.java
@@ -78,11 +78,12 @@ public class Fields<T> extends Generator<T> {
         Class<T> type = types().get(0);
         Object generated = instantiate(type);
 
-        for (Field each : fields) {
+        for (int i = 0; i < fields.size(); i++) {
+            Field each = fields.get(i);
             setField(
                 each,
                 generated,
-                gen().field(each).generate(random, status),
+                fieldGenerators.get(i).generate(random, status),
                 true);
         }
 

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/LocaleGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/LocaleGenerator.java
@@ -37,11 +37,13 @@ import static java.util.Locale.*;
  * Produces values of type {@link Locale}.
  */
 public class LocaleGenerator extends Generator<Locale> {
+    private final static Locale[] availableLocales = getAvailableLocales();
+
     public LocaleGenerator() {
         super(Locale.class);
     }
 
     @Override public Locale generate(SourceOfRandomness random, GenerationStatus status) {
-        return random.choose(getAvailableLocales());
+        return random.choose(availableLocales);
     }
 }

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/RFC4122.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/RFC4122.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.UUID;
@@ -88,7 +89,7 @@ public final class RFC4122 {
         @Override public UUID generate(SourceOfRandomness random, GenerationStatus status) {
             digest.reset();
             digest.update((namespace == null ? Namespaces.URL : namespace.value()).bytes);
-            digest.update(stringGenerator.generate(random, status).getBytes(Charset.forName("UTF-8")));
+            digest.update(stringGenerator.generate(random, status).getBytes(StandardCharsets.UTF_8));
 
             byte[] hash = digest.digest();
             setVersion(hash, (byte) versionMask);

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/TimeZoneGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/TimeZoneGenerator.java
@@ -37,11 +37,13 @@ import static java.util.TimeZone.*;
  * Produces values of type {@link TimeZone}.
  */
 public class TimeZoneGenerator extends Generator<TimeZone> {
+    private final static String[] availableIDs = getAvailableIDs();
+
     public TimeZoneGenerator() {
         super(TimeZone.class);
     }
 
     @Override public TimeZone generate(SourceOfRandomness random, GenerationStatus status) {
-        return getTimeZone(random.choose(getAvailableIDs()));
+        return getTimeZone(random.choose(availableIDs));
     }
 }

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/BiPredicateGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/BiPredicateGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.BiPredicate;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -40,13 +42,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <U> type of second parameter of produced predicate
  */
 public class BiPredicateGenerator<T, U> extends ComponentizedGenerator<BiPredicate> {
+    private Generator<Boolean> generator;
+
     public BiPredicateGenerator() {
         super(BiPredicate.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(boolean.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public BiPredicate<T, U> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(BiPredicate.class, gen().type(boolean.class), status);
+        return makeLambda(BiPredicate.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/PredicateGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/PredicateGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.Predicate;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -39,13 +41,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <T> type of parameter of produced predicate
  */
 public class PredicateGenerator<T> extends ComponentizedGenerator<Predicate> {
+    private Generator<Boolean> generator;
+
     public PredicateGenerator() {
         super(Predicate.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(boolean.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public Predicate<T> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(Predicate.class, gen().type(boolean.class), status);
+        return makeLambda(Predicate.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToDoubleBiFunctionGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToDoubleBiFunctionGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.ToDoubleBiFunction;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -40,13 +42,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <U> type of second parameter of produced function
  */
 public class ToDoubleBiFunctionGenerator<T, U> extends ComponentizedGenerator<ToDoubleBiFunction> {
+    private Generator<Double> generator;
+
     public ToDoubleBiFunctionGenerator() {
         super(ToDoubleBiFunction.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(double.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public ToDoubleBiFunction<T, U> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(ToDoubleBiFunction.class, gen().type(double.class), status);
+        return makeLambda(ToDoubleBiFunction.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToDoubleFunctionGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToDoubleFunctionGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.ToDoubleFunction;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -39,13 +41,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <T> type of parameter of produced function
  */
 public class ToDoubleFunctionGenerator<T> extends ComponentizedGenerator<ToDoubleFunction> {
+    private Generator<Double> generator;
+
     public ToDoubleFunctionGenerator() {
         super(ToDoubleFunction.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(double.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public ToDoubleFunction<T> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(ToDoubleFunction.class, gen().type(double.class), status);
+        return makeLambda(ToDoubleFunction.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToIntBiFunctionGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToIntBiFunctionGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.ToIntBiFunction;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -40,13 +42,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <U> type of second parameter of produced function
  */
 public class ToIntBiFunctionGenerator<T, U> extends ComponentizedGenerator<ToIntBiFunction> {
+    private Generator<Integer> generator;
+
     public ToIntBiFunctionGenerator() {
         super(ToIntBiFunction.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(int.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public ToIntBiFunction<T, U> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(ToIntBiFunction.class, gen().type(int.class), status);
+        return makeLambda(ToIntBiFunction.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToIntFunctionGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToIntFunctionGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.ToIntFunction;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -39,13 +41,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <T> type of parameter of produced function
  */
 public class ToIntFunctionGenerator<T> extends ComponentizedGenerator<ToIntFunction> {
+    private Generator<Integer> generator;
+
     public ToIntFunctionGenerator() {
         super(ToIntFunction.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(int.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public ToIntFunction<T> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(ToIntFunction.class, gen().type(int.class), status);
+        return makeLambda(ToIntFunction.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToLongBiFunctionGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToLongBiFunctionGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.ToLongBiFunction;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -40,13 +42,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <U> type of second parameter of produced function
  */
 public class ToLongBiFunctionGenerator<T, U> extends ComponentizedGenerator<ToLongBiFunction> {
+    private Generator<Long> generator;
+
     public ToLongBiFunctionGenerator() {
         super(ToLongBiFunction.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(long.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public ToLongBiFunction<T, U> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(ToLongBiFunction.class, gen().type(long.class), status);
+        return makeLambda(ToLongBiFunction.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {

--- a/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToLongFunctionGenerator.java
+++ b/generators/src/main/java/com/pholser/junit/quickcheck/generator/java/util/function/ToLongFunctionGenerator.java
@@ -29,6 +29,8 @@ import java.util.function.ToLongFunction;
 
 import com.pholser.junit.quickcheck.generator.ComponentizedGenerator;
 import com.pholser.junit.quickcheck.generator.GenerationStatus;
+import com.pholser.junit.quickcheck.generator.Generator;
+import com.pholser.junit.quickcheck.generator.Generators;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 
 import static com.pholser.junit.quickcheck.generator.Lambdas.*;
@@ -39,13 +41,21 @@ import static com.pholser.junit.quickcheck.generator.Lambdas.*;
  * @param <T> type of parameter of produced function
  */
 public class ToLongFunctionGenerator<T> extends ComponentizedGenerator<ToLongFunction> {
+    private Generator<Long> generator;
+
     public ToLongFunctionGenerator() {
         super(ToLongFunction.class);
     }
 
+    @Override
+    public void provide(Generators provided) {
+        super.provide(provided);
+        generator = gen().type(long.class);
+    }
+
     @SuppressWarnings("unchecked")
     @Override public ToLongFunction<T> generate(SourceOfRandomness random, GenerationStatus status) {
-        return makeLambda(ToLongFunction.class, gen().type(long.class), status);
+        return makeLambda(ToLongFunction.class, generator, status);
     }
 
     @Override public int numberOfNeededComponents() {


### PR DESCRIPTION
It takes time to instantiate and configure generator, so it should not be
instantiated inside generate(...) calls.

fixes #238