### PR TITLE
Fixing arrayOfFunction test that wrongly asserts on SuperShortToExtendsInteger

### DIFF
--- a/guava/src/test/java/com/pholser/junit/quickcheck/guava/generator/FunctionPropertyParameterTypesTest.java
+++ b/guava/src/test/java/com/pholser/junit/quickcheck/guava/generator/FunctionPropertyParameterTypesTest.java
@@ -82,7 +82,7 @@ public class FunctionPropertyParameterTypesTest {
 
     @Test public void arrayOfFunction() throws Exception {
         assertThat(testResult(ArrayOfFunction.class), isSuccessful());
-        assertEquals(defaultPropertyTrialCount(), SuperShortToExtendsInteger.iterations);
+        assertEquals(defaultPropertyTrialCount(), ArrayOfFunction.iterations);
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
Currently, test `arrayOfFunction` fails when run by itself. The test seems to wrongly assert on `SuperShortToExtendsInteger` instead of `ArrayOfFunction`, so it originally only "passes" when run after `superShortToInteger`. This pull request changes the assertion to use `ArrayOfFunction` instead.