### PR TITLE
For #267, invoke FrameworkField ctor reflectively

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheck.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheck.java
@@ -38,7 +38,6 @@ import org.junit.Test;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.JUnitQuickcheckTestClass;
 import org.junit.runners.model.Statement;
 import org.junit.runners.model.TestClass;
 import org.slf4j.Logger;

--- a/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheckTestClass.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/runner/JUnitQuickcheckTestClass.java
@@ -23,9 +23,10 @@
  WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-package org.junit.runners.model;
+package com.pholser.junit.quickcheck.runner;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -37,6 +38,9 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import org.junit.internal.MethodSorter;
+import org.junit.runners.model.FrameworkField;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.TestClass;
 
 import static java.util.stream.Collectors.*;
 
@@ -66,9 +70,20 @@ public class JUnitQuickcheckTestClass extends TestClass {
                 addToAnnotationLists(new FrameworkMethod(each), annotatedMethods);
             }
             for (Field each : applicableFieldsOf(c)) {
-                addToAnnotationLists(new FrameworkField(each), annotatedFields);
+                addToAnnotationLists(makeFrameworkField(each), annotatedFields);
             }
         });
+    }
+
+    private FrameworkField makeFrameworkField(Field field) {
+        try {
+            Constructor<FrameworkField> ctor =
+                FrameworkField.class.getDeclaredConstructor(Field.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(field);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static List<Method> applicableMethodsOf(Class<?> clazz) {

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <version>4.13</version>
             </dependency>
 
             <dependency>
@@ -363,6 +363,40 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <source>8</source>
+                        <show>protected</show>
+                        <nohelp>true</nohelp>
+                        <header>junit-quickcheck ${project.version}</header>
+                        <footer>junit-quickcheck ${project.version}</footer>
+                        <doctitle>junit-quickcheck ${project.version}</doctitle>
+                        <excludePackageNames>*.internal.*:org.junit.*</excludePackageNames>
+                        <links>
+                            <link>https://docs.oracle.com/javase/8/docs/api</link>
+                            <link>http://junit.org/junit4/javadoc/latest/</link>
+                            <link>https://guava.dev/releases/29.0-jre/api/docs/</link>
+                        </links>
+                        <bottom><![CDATA[<i>&copy; Copyright 2010-2020 Paul R. Holser, Jr.  All rights reserved. Licensed under The MIT License. pholser@alumni.rice.edu</i>]]></bottom>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <goals>
+                                <goal>javadoc</goal>
+                            </goals>
+                            <phase>site</phase>
+                        </execution>
+                    </executions>
+                </plugin>
 
             </plugins>
         </pluginManagement>
@@ -378,40 +412,6 @@
                         <goals>
                             <goal>jar-no-fork</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <goals>
-                            <goal>javadoc</goal>
-                        </goals>
-                        <phase>site</phase>
-                        <configuration>
-                            <source>1.8</source>
-                            <show>protected</show>
-                            <nohelp>true</nohelp>
-                            <header>junit-quickcheck ${project.version}</header>
-                            <footer>junit-quickcheck ${project.version}</footer>
-                            <doctitle>junit-quickcheck ${project.version}</doctitle>
-                            <excludePackageNames>*.internal.*:org.junit.*</excludePackageNames>
-                            <links>
-                                <link>https://docs.oracle.com/javase/8/docs/api</link>
-                                <link>http://junit.org/junit4/javadoc/latest/</link>
-                                <link>https://guava.dev/releases/29.0-jre/api/docs/</link>
-                            </links>
-                            <bottom><![CDATA[<i>&copy; Copyright 2010-2020 Paul R. Holser, Jr.  All rights reserved. Licensed under The MIT License. pholser@alumni.rice.edu</i>]]></bottom>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Upgrading to JUnit 4.13 also.

This will prevent the symptom whereby user gets a SecurityError running
on newer JDKs b/c the class invoking the ctor directly previously was
in the same package as FrameworkField (to allow package-private access)
but in a different JAR file.