### PR TITLE
Fix Nondeterministic Ordering in Tests

### DIFF
--- a/core/src/main/java/com/pholser/junit/quickcheck/internal/ParameterTypeContext.java
+++ b/core/src/main/java/com/pholser/junit/quickcheck/internal/ParameterTypeContext.java
@@ -37,6 +37,7 @@ import static java.util.Collections.unmodifiableList;
 import static org.javaruntype.type.Types.arrayComponentOf;
 
 import com.pholser.junit.quickcheck.From;
+import com.pholser.junit.quickcheck.Produced;
 import com.pholser.junit.quickcheck.generator.Generator;
 import com.pholser.junit.quickcheck.random.SourceOfRandomness;
 import java.lang.reflect.AnnotatedArrayType;
@@ -52,6 +53,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import org.javaruntype.type.ExtendsTypeParameter;
@@ -205,10 +207,15 @@ public class ParameterTypeContext {
     public ParameterTypeContext annotate(AnnotatedElement element) {
         this.annotatedElement = element;
 
-        List<From> generators = allAnnotationsByType(element, From.class);
-        if (!generators.isEmpty() && element instanceof AnnotatedWildcardType)
-            throw new IllegalArgumentException("Wildcards cannot be marked with @From");
-
+        List<Produced> producedGenerators = allAnnotationsByType(element, Produced.class);
+        List<From> generators;
+        if (producedGenerators.size() == 1) {
+            generators = Arrays.asList(producedGenerators.get(0).value());
+        } else {
+            generators = allAnnotationsByType(element, From.class);
+            if (!generators.isEmpty() && element instanceof AnnotatedWildcardType)
+                throw new IllegalArgumentException("Wildcards cannot be marked with @From");
+        }
         addGenerators(generators);
         return this;
     }

--- a/core/src/test/java/com/pholser/junit/quickcheck/internal/ReflectionTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/internal/ReflectionTest.java
@@ -552,8 +552,13 @@ public class ReflectionTest {
         assertEquals(4, annotations.size());
         assertEquals(X.class, annotations.get(0).annotationType());
         assertEquals(Y.class, annotations.get(1).annotationType());
-        assertEquals(Z.class, annotations.get(2).annotationType());
-        assertEquals(W.class, annotations.get(3).annotationType());
+        assertTrue(Z.class.equals(annotations.get(2).annotationType()) ||
+            W.class.equals(annotations.get(2).annotationType()));
+        if (Z.class.equals(annotations.get(2).annotationType())) {
+            assertEquals(W.class, annotations.get(3).annotationType());
+        } else {
+            assertEquals(Z.class, annotations.get(3).annotationType());
+        }
     }
 
     public void withMarker(@X String s) {


### PR DESCRIPTION
ExplicitGroupOfPropertyParameterGeneratorsChosenWithEqualProbabilityTest and ExplicitGroupOfPropertyParameterGeneratorsChosenWithDiscreteProbabilityTest's `producesExpectedRandomValues` test is nondeterministic. When setting up the test, the list of generators is obtained from `ParameterTypeContext#annotate` which uses `Reflection#allAnnotationsByType` to get all of the `From` annotations. However, internally, `Reflection#allAnnotationsByType` uses the `getAnnotationsByType` method which according to posts such as this: https://stackoverflow.com/questions/16756291/is-java-annotation-order-persistent does not guarantee the order the annotations are returned in. As a result, the generators used by these tests could be returned in a different order than expected. The proposed change in `ParamterTypeContext` is meant to first check if there is a `Produced` annotation. If one exists, the `From` annotations can be obtained from there. The order of `From` annotations obtained by using `Produced#value` is guaranteed.

The change in `ReflectionTest` is due to the fact that the `Reflection#allAnnotations` method relies on `Reflection#nonSystemAnnotations` which relies on `getAnnotations`. This function also has no documented order that annotations are returned. As a result, the order that the `Z` and `W` annotation are obtained is not guaranteed.