### PR TITLE
Fix flakiness in UsualJUnitMachineryOnSubclassPropertyTest

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnSubclassPropertyTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnSubclassPropertyTest.java
@@ -50,7 +50,7 @@ import org.junit.rules.ExternalResource;
 import org.junit.runner.RunWith;
 
 public class UsualJUnitMachineryOnSubclassPropertyTest {
-    private static final OutputStream bytesOut = new ByteArrayOutputStream();
+    private static final ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
     private static final PrintStream fakeOut =
         new PrintStream(bytesOut, true);
 
@@ -65,11 +65,15 @@ public class UsualJUnitMachineryOnSubclassPropertyTest {
             }
         };
 
+    @After public void clearBytesOut() throws Exception {
+        bytesOut.reset();
+    }
+
     @Test public void expectedOrderingOfMethods() throws Exception {
         assertThat(testResult(Leaf.class), isSuccessful());
         assertEquals(
             resourceAsString("subclass-property-test-expected.txt"),
-            bytesOut.toString());
+            bytesOut.toString().replaceAll(System.lineSeparator(), "\r\n"));
     }
 
     public static abstract class Root {


### PR DESCRIPTION
The test `com.pholser.junit.quickcheck.UsualJUnitMachineryOnSubclassPropertyTest.expectedOrderingOfMethods` is system-dependent and fails when running on Mac. In addition, it's non-idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to remove the system dependence so that it can be run consistently on every platform.  Furthermore, the state pollution may be removed so that some other tests do not fail in the future due to the shared state polluted by these tests.

### Details

#### System dependence

`UsualJUnitMachineryOnSubclassPropertyTest.expectedOrderingOfMethods` fails in the following assertion on Mac:
```
assertEquals(resourceAsString("subclass-property-test-expected.txt"), bytesOut.toString());
```
The root cause is that the expected resource string is using CRLF`(\r\n)` as the line separator, while the line separator for the `bytesOut.toString()` is dependent on the `line.separator` system property, which is OS-dependent.

The suggested fix is to replace the line separator in the `bytesOut.toString()` to with CRLF`(\r\n)` and run the comparison on that.

#### non-Idempotence
In addition, `UsualJUnitMachineryOnSubclassPropertyTest.expectedOrderingOfMethods` fails if run twice in the same JVM, because `bytesOut` is modified between runs. The fix for that is to clear the static `bytesOut` stream after the test.

With the suggested fixes, the test passes(on Mac), and does not pollute the shared state(also passes when run twice in the same JVM).