### PR TITLE
Fix flakiness in UsualJUnitMachineryOnTraitBasedPropertyTest

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnTraitBasedPropertyTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnTraitBasedPropertyTest.java
@@ -50,7 +50,7 @@ import org.junit.rules.ExternalResource;
 import org.junit.runner.RunWith;
 
 public class UsualJUnitMachineryOnTraitBasedPropertyTest {
-    private static final OutputStream bytesOut = new ByteArrayOutputStream();
+    private static final ByteArrayOutputStream bytesOut = new ByteArrayOutputStream();
     private static final PrintStream fakeOut =
         new PrintStream(bytesOut, true);
 
@@ -65,11 +65,15 @@ public class UsualJUnitMachineryOnTraitBasedPropertyTest {
             }
         };
 
+    @After public void clearBytesOut() throws Exception {
+        bytesOut.reset();
+    }
+
     @Test public void expectedOrderingOfMethods() throws Exception {
         assertThat(testResult(Leaf.class), isSuccessful());
         assertEquals(
             resourceAsString("trait-property-test-expected.txt"),
-            bytesOut.toString());
+            bytesOut.toString().replaceAll(System.lineSeparator(), "\r\n"));
     }
 
     public interface TraitA {


### PR DESCRIPTION
The test `com.pholser.junit.quickcheck.UsualJUnitMachineryOnTraitBasedPropertyTest.expectedOrderingOfMethods` is system-dependent and fails when running on Mac. In addition, it's non-idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to remove the system dependence so that it can be run consistently on every platform. Furthermore, the state pollution may be removed so that some other tests do not fail in the future due to the shared state polluted by these tests.

## Details
The root cause is similar to what's detailed in https://github.com/pholser/junit-quickcheck/pull/286 .

With the suggested fixes, the test passes(on Mac), and does not pollute the shared state(also passes when run twice in the same JVM).