### PR TITLE
Clear logs after test in UsualJUnitMachineryOnPropertyBasedTest

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnPropertyBasedTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnPropertyBasedTest.java
@@ -73,6 +73,7 @@ public class UsualJUnitMachineryOnPropertyBasedTest {
     @Test public void orderingOfStatements() {
         assertThat(testResult(PropertyBasedTests.class), isSuccessful());
         assertEquals(expectedStatements, PropertyBasedTests.LOGS);
+        PropertyBasedTests.clearLogs();
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -162,6 +163,10 @@ public class UsualJUnitMachineryOnPropertyBasedTest {
 
         @Test public void aTest() {
             LOGS.add("test");
+        }
+
+        public static void clearLogs() {
+            LOGS.clear();
         }
     }
 }


### PR DESCRIPTION
The test `com.pholser.junit.quickcheck.UsualJUnitMachineryOnPropertyBasedTest.orderingOfStatements` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

## Brief changelog

Added a static method `clearLogs()` in `PropertyBasedTests` class to clear the logs. When `UsualJUnitMachineryOnPropertyBasedTest.orderingOfStatements()` finishes, call `PropertyBasedTests.clearLogs()` to clear all the logs.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).
