### PR TITLE
Clear logs in UsualJUnitMachineryOnShrinkingPropertyBasedTest

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnShrinkingPropertyBasedTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/UsualJUnitMachineryOnShrinkingPropertyBasedTest.java
@@ -69,6 +69,7 @@ public class UsualJUnitMachineryOnShrinkingPropertyBasedTest {
     @Test public void orderingOfStatements() {
         assertThat(testResult(PropertyBasedTests.class), failureCountIs(1));
         assertEquals(expectedStatements, PropertyBasedTests.LOGS);
+        PropertyBasedTests.clearLogs();
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -135,6 +136,10 @@ public class UsualJUnitMachineryOnShrinkingPropertyBasedTest {
             LOGS.add("property");
 
             fail();
+        }
+
+        public static void clearLogs() {
+            LOGS.clear();
         }
     }
 }


### PR DESCRIPTION
The test `com.pholser.junit.quickcheck.UsualJUnitMachineryOnShrinkingPropertyBasedTest.orderingOfStatements` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test. 

The root cause and suggest fix are identical  to the ones in https://github.com/pholser/junit-quickcheck/pull/288 .

## Brief changelog

Added a static method `clearLogs()` in `PropertyBasedTests` class to clear the logs. When `UsualJUnitMachineryOnShrinkingPropertyBasedTest.orderingOfStatements()` finishes, call `PropertyBasedTests.clearLogs()` to clear all the logs.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

