### PR TITLE
Clear the shared state after some tests

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
@@ -120,6 +120,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList((byte) 12, (byte) -13)),
             new HashSet<>(PrimitiveBytes.values.subList(0, 2)));
+        PrimitiveBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
@@ -187,6 +187,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList('@', '#')),
             new HashSet<>(WrapperChars.values.subList(0, 2)));
+        WrapperChars.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
The tests
`com.pholser.junit.quickcheck.SamplingButAlsoIncludingAGivenSetTest.primitiveBytes` and
`com.pholser.junit.quickcheck.SamplingButAlsoIncludingAGivenSetTest.wrapperChars`
 are not idempotent and fail if run twice in the same JVM, because they pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by these tests.

**Brief changelog**
Clear the counter `PrimitiveBytes.iterations` at the end of test `primitiveBytes`.
Clear the counter `WrapperChars.iterations` at the end of test `wrapperChars`.
**Verifying this change**
With the proposed fix, the tests do not pollute the shared state (and pass when run twice in the same JVM).