### PR TITLE
Update PropertyExhaustiveSampleSizeTest.java

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/PropertyExhaustiveSampleSizeTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PropertyExhaustiveSampleSizeTest.java
@@ -49,6 +49,7 @@ public class PropertyExhaustiveSampleSizeTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ForDefaultNumberOfValues.iterations);
+        ForDefaultNumberOfValues.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
The test 
`com.pholser.junit.quickcheck.PropertyExhaustiveSampleSizeTest.shouldFeedADefaultNumberOfValuesToAProperty`
 is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

**Brief changelog**
Clear the counter `ForDefaultNumberOfValues.iterations` after the test `shouldFeedADefaultNumberOfValuesToAProperty`
**Verifying this change**
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).