### PR TITLE
Update PropertiesWithExplicitGeneratorsTest.java

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/PropertiesWithExplicitGeneratorsTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PropertiesWithExplicitGeneratorsTest.java
@@ -279,6 +279,7 @@ public class PropertiesWithExplicitGeneratorsTest {
     @Test public void explicitGeneratorTakesPrecedence() {
         assertThat(testResult(WithExplicitGenerator.class), isSuccessful());
         assertEquals(asList(0, 1, 2, 3, 4), WithExplicitGenerator.values);
+        WithExplicitGenerator.values.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
The test 
`com.pholser.junit.quickcheck.PropertiesWithExplicitGeneratorsTest.explicitGeneratorTakesPrecedence`
 is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

**Brief changelog**
Clear the static List `WithExplicitGenerator.values` at the end of the test `explicitGeneratorTakesPrecedence`
**Verifying this change**
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).
