### PR TITLE
Reset VoidParameter.iterations after PrimitivePropertyParameterTypesTest.voidParameter() test

### DIFF
--- a/generators/src/test/java/com/pholser/junit/quickcheck/PrimitivePropertyParameterTypesTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/PrimitivePropertyParameterTypesTest.java
@@ -1317,6 +1317,7 @@ public class PrimitivePropertyParameterTypesTest {
     @Test public void voidParameter() throws Exception {
         assertThat(testResult(VoidParameter.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), VoidParameter.iterations);
+        VoidParameter.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
The test `com.pholser.junit.quickcheck.PrimitivePropertyParameterTypesTest.voidParameter` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

## Brief changelog

Reset `VoidParameter.iterations` to 0 at the end of `voidParameter()` test.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).
