### PR TITLE
Reset CallableOfInt.iterations after test callable()

### DIFF
--- a/generators/src/test/java/com/pholser/junit/quickcheck/CallablePropertyParameterTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/CallablePropertyParameterTest.java
@@ -43,6 +43,7 @@ public class CallablePropertyParameterTest {
     @Test public void callable() throws Exception {
         assertThat(testResult(CallableOfInt.class), isSuccessful());
         assertEquals(defaultPropertyTrialCount(), CallableOfInt.iterations);
+        CallableOfInt.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
The test `com.pholser.junit.quickcheck.CallablePropertyParameterTest.callable` is not idempotent and fails if run twice in the same JVM, because it pollutes state shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

## Brief changelog

Reset `CallableOfInt.iterations` to 0 at the end of `callable()` test.

## Verifying this change
With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).
