### PR TITLE
Clean shared state pollution to avoid flaky tests in module core

### DIFF
--- a/core/src/test/java/com/pholser/junit/quickcheck/ExhaustingAGivenSetButIncludingAnotherTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/ExhaustingAGivenSetButIncludingAnotherTest.java
@@ -76,6 +76,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             singletonList(true),
             PrimitiveBooleans.values.subList(0, 1));
+        PrimitiveBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -118,6 +119,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             new HashSet<>(asList(Byte.valueOf("12"), Byte.valueOf("-13"))),
             new HashSet<>(PrimitiveBytes.values.subList(0, 2)));
+        PrimitiveBytes.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -461,6 +463,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             EnumSet.of(HALF_UP, HALF_EVEN),
             new HashSet<>(Enums.values.subList(0, 2)));
+        Enums.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -485,6 +488,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
             new HashSet<>(
                 asList(new CtorOnly.Target("a"), new CtorOnly.Target("b"))),
             new HashSet<>(CtorOnly.values.subList(0, 2)));
+        CtorOnly.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -630,6 +634,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
                 LocalDate.of(2017, 1, 1),
                 LocalDate.of(2001, 12, 25))),
             new HashSet<>(ExplicitConversion.values.subList(0, 2)));
+        ExplicitConversion.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -691,6 +696,7 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             asList('r', 'r', 'r', 'r', 'y', 'y', 'y', 'y'),
             ManyParameters.secondTestCases.subList(0, 8));
+        ManyParameters.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -763,6 +769,8 @@ public class ExhaustingAGivenSetButIncludingAnotherTest {
         assertEquals(
             EnumSet.allOf(RoundingMode.class),
             new HashSet<>(ManyParametersWithBooleanAndEnum.fourthTestCases));
+        ManyParametersWithBooleanAndEnum.iterations = 0;
+        ManyParametersWithBooleanAndEnum.fourthTestCases.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/PropertyParameterConfigurationIsolationTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PropertyParameterConfigurationIsolationTest.java
@@ -45,6 +45,7 @@ public class PropertyParameterConfigurationIsolationTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ParametersOfSameType.iterations);
+        ParametersOfSameType.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -68,6 +69,7 @@ public class PropertyParameterConfigurationIsolationTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ParametersOfSameTypeWithOneConstant.iterations);
+        ParametersOfSameTypeWithOneConstant.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -91,6 +93,7 @@ public class PropertyParameterConfigurationIsolationTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ParametersOfSameParameterizedType.iterations);
+        ParametersOfSameParameterizedType.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -116,6 +119,7 @@ public class PropertyParameterConfigurationIsolationTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ParametersOfSameParameterizedTypeWithOneConstant.iterations);
+        ParametersOfSameParameterizedTypeWithOneConstant.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -161,6 +165,7 @@ public class PropertyParameterConfigurationIsolationTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ParametersOfSameArrayType.iterations);
+        ParametersOfSameArrayType.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -216,6 +221,7 @@ public class PropertyParameterConfigurationIsolationTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ParametersOfArrayTypeAndTypeWithOneConstant.iterations);
+        ParametersOfArrayTypeAndTypeWithOneConstant.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/PropertyTupleSampleSizeTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/PropertyTupleSampleSizeTest.java
@@ -46,6 +46,7 @@ public class PropertyTupleSampleSizeTest {
         assertEquals(
             defaultPropertyTrialCount(),
             ForDefaultNumberOfValues.iterations);
+        ForDefaultNumberOfValues.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -62,6 +63,7 @@ public class PropertyTupleSampleSizeTest {
             testResult(ForSpecifiedNumberOfValues.class),
             isSuccessful());
         assertEquals(5, ForSpecifiedNumberOfValues.iterations);
+        ForSpecifiedNumberOfValues.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -79,6 +81,7 @@ public class PropertyTupleSampleSizeTest {
             testResult(ForValuesOfMultipleParameters.class),
             isSuccessful());
         assertEquals(21, ForValuesOfMultipleParameters.iterations);
+        ForValuesOfMultipleParameters.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)

--- a/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
+++ b/core/src/test/java/com/pholser/junit/quickcheck/SamplingButAlsoIncludingAGivenSetTest.java
@@ -75,6 +75,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(true, false)),
             new HashSet<>(PrimitiveBooleans.values));
+        PrimitiveBooleans.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -165,6 +166,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList('Z', 'z')),
             new HashSet<>(PrimitiveChars.values.subList(0, 2)));
+        PrimitiveChars.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -210,6 +212,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(3.2, -4D)),
             new HashSet<>(PrimitiveDoubles.values.subList(0, 2)));
+        PrimitiveDoubles.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -232,6 +235,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList(2.7, -3.14)),
             new HashSet<>(WrapperDoubles.values.subList(0, 2)));
+        WrapperDoubles.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -454,6 +458,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             EnumSet.of(HALF_UP, HALF_EVEN),
             new HashSet<>(Enums.values.subList(0, 2)));
+        Enums.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -477,6 +482,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
             new HashSet<>(
                 asList(new CtorOnly.Target("a"), new CtorOnly.Target("b"))),
             new HashSet<>(CtorOnly.values.subList(0, 2)));
+        CtorOnly.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -534,6 +540,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
                     FavorValueOf.Target.valueOf("a"),
                     FavorValueOf.Target.valueOf("b"))),
             new HashSet<>(FavorValueOf.values.subList(0, 2)));
+        FavorValueOf.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -622,6 +629,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
                     LocalDate.of(2017, 1, 1),
                     LocalDate.of(2001, 12, 25))),
             new HashSet<>(ExplicitConversion.values.subList(0, 2)));
+        ExplicitConversion.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -673,6 +681,7 @@ public class SamplingButAlsoIncludingAGivenSetTest {
         assertEquals(
             new HashSet<>(asList('r', 'y')),
             new HashSet<>(ManyParameters.secondValues.subList(0, 2)));
+        ManyParameters.iterations = 0;
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -708,6 +717,8 @@ public class SamplingButAlsoIncludingAGivenSetTest {
                 AlsoHonorsGenerators.values.subList(
                     3,
                     AlsoHonorsGenerators.values.size())));
+        AlsoHonorsGenerators.iterations = 0;
+        AlsoHonorsGenerators.values.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
This PR is similar to #286 and #294.

1. Failed Tests:
- This PR fixes 26 flaky tests in module `core`, in 4 classes:
```
com.pholser.junit.quickcheck.ExhaustingAGivenSetButIncludingAnotherTest
com.pholser.junit.quickcheck.PropertyParameterConfigurationIsolationTest
com.pholser.junit.quickcheck.PropertyTupleSampleSizeTest
com.pholser.junit.quickcheck.SamplingButAlsoIncludingAGivenSetTest
```
2. Why they fail

- These tests pollute the state shared among tests without clearing `xxx.iterations`. For example, ```com.pholser.junit.quickcheck.ExhaustingAGivenSetButIncludingAnotherTest.manyParameters``` does not clear `ManyParameters.iterations`.
- It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state polluted by these tests.

3. Reproduce test failures

- Take ```com.pholser.junit.quickcheck.ExhaustingAGivenSetButIncludingAnotherTest.manyParameters``` for example:

  Step1. Add a copy:
`@Test public void copymanyParameters() { manyParameters(); }`
  Step2. Run:
`mvn -pl core test -Dtest=com.pholser.junit.quickcheck.ExhaustingAGivenSetButIncludingAnotherTest`

- we can get failure: `java.lang.AssertionError: expected:<16> but was:<32>`

4. Fix them
- Reset the appropriate `xxx.iterations` to 0 at the end of each test.