### PR TITLE
Clean shared state pollution to avoid flaky tests.

### DIFF
--- a/generators/src/test/java/com/pholser/junit/quickcheck/PrimitivePropertyParameterTypesTest.java
+++ b/generators/src/test/java/com/pholser/junit/quickcheck/PrimitivePropertyParameterTypesTest.java
@@ -74,6 +74,7 @@ public class PrimitivePropertyParameterTypesTest {
         assertEquals(
             asList(false, true),
             PrimitiveBooleanWithAllValues.values);
+        PrimitiveBooleanWithAllValues.values.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)
@@ -90,6 +91,7 @@ public class PrimitivePropertyParameterTypesTest {
             testResult(WrapperBooleanWithAllValues.class),
             isSuccessful());
         assertEquals(asList(false, true), WrapperBooleanWithAllValues.values);
+        WrapperBooleanWithAllValues.values.clear();
     }
 
     @RunWith(JUnitQuickcheck.class)


### PR DESCRIPTION
This PR is similar to recently opened #357 and previously merged #294 and #295.

1. Failed Tests:
- This PR fixes 2 flaky tests in module `generators`:
```
com.pholser.junit.quickcheck.PrimitivePropertyParameterTypesTest.primitiveBooleanWithAllValues
com.pholser.junit.quickcheck.PrimitivePropertyParameterTypesTest.wrapperBooleanWithAllValues
```
2. Why they fail

- These tests pollute the state shared among tests without clearing `PrimitiveBooleanWithAllValues.values` and `WrapperBooleanWithAllValues.values`
- It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state polluted by these tests.

3. Reproduce test failures

- Take ```com.pholser.junit.quickcheck.PrimitivePropertyParameterTypesTest.primitiveBooleanWithAllValues``` for example:

  Step1. Add a copy:
`@Test public void copyprimitiveBooleanWithAllValues() { primitiveBooleanWithAllValues(); }`
  Step2. Run:
`mvn -pl generators test -Dtest=com.pholser.junit.quickcheck.PrimitivePropertyParameterTypesTest`

- we can get failure: `primitiveBooleanWithAllValues:74 expected:<[false, true]> but was:<[false, true, false, true]>`

4. Fix
- By clearing the values of `ArrayList` at the end of each test.

